### PR TITLE
fix(rules): remove dynamic import race in .withRules()/.audit()

### DIFF
--- a/docs/issues/2026-04-24-free-function-db-wrappers.md
+++ b/docs/issues/2026-04-24-free-function-db-wrappers.md
@@ -1,0 +1,157 @@
+# Issue: Migrate `.withRules()` / `.audit()` from chainable methods to free functions
+
+**Opened:** 2026-04-24
+**Status:** Tracking (not in flight)
+**Target:** v0.8.0 (major-version API change)
+**Relates-to:** PR #59 (tactical fix for the lazy-load race)
+
+## Context
+
+PR #59 resolved a latent race in the rules/db module boundary: `rules.ts`
+subclassed base classes from `db.ts`, which in turn needed rules.ts's factory
+functions to implement `.withRules()` / `.audit()`. The cycle was previously
+broken by a `dynamic import('./rules')` in db.ts — which worked, but the
+resulting promise could be unsettled when consumer code called `.audit()` at
+mutation wire-up time (see hotpot's `internalMutations.ts` TODO).
+
+PR #59 replaced that with a synchronous installer (`installRulesSubclasses`)
+that db.ts calls at the end of its own module body. This fixes the race,
+but does not eliminate the underlying circular dependency — it just sequences
+the initialization carefully so the cycle resolves in one tick instead of
+across a promise boundary.
+
+## Why we didn't do a structural fix now
+
+A genuine structural resolution was sketched (see brainstorm in PR #59
+review). The three options considered:
+
+1. **Extract base classes into `dbClasses.ts`.** Attractive on paper. But
+   the `.withRules()` / `.audit()` methods live on the base classes (that's
+   what makes chaining work), and those methods call into rules.ts factories.
+   Either the cycle comes back, the methods move off the base (and chaining
+   breaks), or a sibling registration mechanism replaces the current
+   installer — which is the same indirection relocated, not removed.
+2. **Merge rules.ts into db.ts.** Declaration order would be sufficient.
+   But the combined file is ~1500 lines and conflates two legitimately
+   distinct concerns (codec-at-boundary vs. rules/audit middleware).
+3. **Make `.withRules()` / `.audit()` free functions.** Eliminates the
+   cycle at the structural level: db.ts has no runtime dep on rules.ts at
+   all; rules.ts imports db.ts for types only. Breaking API change.
+
+The blocker for Option 1 is the chaining requirement — as long as
+`ctx.db.withRules(...).audit(...)` has to work as method chains, the
+wrappers need methods on the base class, which means the base class has
+to know about the factories, which means some form of cycle or deferred
+wiring.
+
+Option 3 is the only truly cycle-free shape, and it requires giving up
+chaining.
+
+## The v0.8.0 migration
+
+Replace:
+
+```ts
+const secureDb = ctx.db
+  .withRules(ctx, rules)
+  .audit({ afterWrite })
+```
+
+with:
+
+```ts
+import { withRules, audit } from 'zodvex/server'
+
+const secureDb = audit(
+  withRules(ctx.db, ctx, rules),
+  { afterWrite }
+)
+```
+
+`withRules` and `audit` become standalone functions exported from
+`zodvex/server`. They take a `ZodvexDatabaseReader`/`Writer` as their first
+argument and return the wrapped variant. No methods on the base class.
+
+### After migration, the dependency graph
+
+```
+ruleTypes.ts    (types only)
+    ↓
+db.ts           ← base classes, codec wiring, no runtime dep on rules.ts
+    ↓ (type)
+rules.ts        ← subclasses, `withRules` / `audit` functions
+```
+
+A strict DAG. No installer. No live-binding tricks. No `dynamic import()`.
+Adding a new `extends` can never re-introduce a cycle because the arrow
+only points one way.
+
+### Alignment with prior direction
+
+The `2026-02-17-runtime-only-middleware.md` decision doc ended with a note:
+
+> zodvex v2 moved away from providing hook points entirely — consumers
+> write their own DB wrappers (following Convex's `wrapDatabaseReader`
+> pattern) on top of zodvex's codec layer…
+
+This migration is in the same spirit: wrappers become things consumers
+*apply* to a db object, not methods they *call on* it. Matches Convex's
+own `wrapDatabaseReader` shape more closely, too.
+
+## Scope of the change
+
+### Source changes
+- Move `.withRules()` / `.audit()` method bodies out of base classes in
+  `db.ts` into standalone `withRules` / `audit` exports in `rules.ts`
+  (or a new `wrappers.ts` — tbd).
+- Rename / remove the internal factories (`createRulesDatabaseReader`,
+  etc.) or promote them directly to the public surface.
+- Delete `installRulesSubclasses` + `_subclasses` slot; subclasses go
+  back to top-level class declarations in `rules.ts`.
+- Remove the ESM `let RulesQueryChain` live-binding trick.
+
+### Consumer migration
+- All examples (`examples/task-manager`, `examples/task-manager-mini`,
+  `examples/quickstart`, `examples/stress-test`) need updating.
+- Hotpot (external consumer — coordinate with them).
+- Write a codemod in `packages/zod-to-mini` style that rewrites
+  `db.withRules(...).audit(...)` → `audit(withRules(db, ...), ...)`
+  (AST-aware so it handles nested expressions and the `ctx` argument
+  order correctly).
+
+### Docs
+- Migration guide (`docs/migration/v0.8.md`).
+- Update `docs/guide/custom-context.md` and any other guide that shows
+  `.withRules()` / `.audit()` call sites.
+- Update `CLAUDE.md` architecture section.
+
+## Open questions
+
+1. **Naming**: `withRules` + `audit` as top-level exports, or nest under a
+   namespace (`wrappers.withRules`, `wrappers.audit`)? Former is what
+   React Query-ish APIs do; latter avoids polluting the top-level with
+   common names.
+2. **Type ergonomics**: Method chaining let us thread `DataModel` /
+   `DecodedDocs` generics naturally. As free functions, we need to ensure
+   inference survives composition — `audit(withRules(db, ctx, rules), ...)`
+   should keep the decoded-doc types on the inner `db`. Worth prototyping
+   on a branch before committing to the shape.
+3. **Timing**: v0.8.0 is ambiguous right now. zodvex is still 0.7.x in
+   beta — stabilizing 0.7 should happen before a breaking API change.
+   Realistic window is "after 0.7 ships stable."
+
+## Non-goals
+
+- Don't ship this in a minor version. It's breaking.
+- Don't revisit Option 1 (`dbClasses.ts` extract). The sketch in PR #59
+  showed it's either fake-structural (installer-shaped indirection) or
+  it breaks chaining — at which point you might as well do Option 3.
+- Don't land this and Option C's codemod (zod → zod-mini) in the same
+  release. Consumers should not be asked to run two codemods in one
+  upgrade.
+
+## When to revisit
+
+Whenever we cut 0.8.0. Reference this doc and the PR #59 brainstorm.
+The current installer-based fix is stable and not costing anyone
+anything at runtime — there's no urgency.

--- a/packages/zodvex/__tests__/rules-synchronous-install.test.ts
+++ b/packages/zodvex/__tests__/rules-synchronous-install.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression test for the rules-module lazy-load race.
+ *
+ * Previously, rules.ts was loaded via `dynamic import()` from db.ts to break
+ * a circular dependency. This meant `.withRules()` / `.audit()` could only
+ * be called AFTER the import promise resolved — and anything that wired up
+ * those wrappers synchronously at mutation registration time (e.g.,
+ * `zim.withContext`'s input function running at module init) would throw
+ * "zodvex rules module not yet loaded".
+ *
+ * The fix: rules.ts no longer references db.ts values at module init.
+ * db.ts calls `installRulesSubclasses` at the end of its own module load,
+ * fully synchronously. After importing zodvex's internal db module, the
+ * rules surface is ready immediately.
+ *
+ * These tests exercise calling `.audit()` and `.withRules()` the first
+ * statement after import — the pattern that was previously broken.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { ZodvexDatabaseReader, ZodvexDatabaseWriter } from '../src/internal/db'
+
+function makeMinimalReader(): any {
+  return {
+    system: { get: async () => null, query: () => ({}), normalizeId: () => null },
+    normalizeId: () => null,
+    get: async () => null,
+    query: () => ({})
+  }
+}
+
+function makeMinimalWriter(): any {
+  return {
+    ...makeMinimalReader(),
+    insert: async () => 'id',
+    patch: async () => undefined,
+    replace: async () => undefined,
+    delete: async () => undefined
+  }
+}
+
+describe('rules module is installed synchronously at import', () => {
+  it('reader.audit() is callable the first statement after import', () => {
+    const reader = new ZodvexDatabaseReader(makeMinimalReader(), {})
+    // Must NOT throw "zodvex rules module not yet loaded" — the bug this
+    // test pins down. If it throws, the subclass installer never ran
+    // before this call.
+    expect(() =>
+      reader.audit({
+        afterRead: () => {
+          /* noop */
+        }
+      })
+    ).not.toThrow()
+  })
+
+  it('writer.audit() is callable the first statement after import', () => {
+    const writer = new ZodvexDatabaseWriter(makeMinimalWriter(), {})
+    expect(() =>
+      writer.audit({
+        afterWrite: () => {
+          /* noop */
+        }
+      })
+    ).not.toThrow()
+  })
+
+  it('reader.withRules() is callable the first statement after import', () => {
+    const reader = new ZodvexDatabaseReader(makeMinimalReader(), {})
+    expect(() => reader.withRules({}, {})).not.toThrow()
+  })
+
+  it('writer.withRules() is callable the first statement after import', () => {
+    const writer = new ZodvexDatabaseWriter(makeMinimalWriter(), {})
+    expect(() => writer.withRules({}, {})).not.toThrow()
+  })
+
+  it('chained .withRules().audit() works without intervening await', () => {
+    const writer = new ZodvexDatabaseWriter(makeMinimalWriter(), {})
+    // This is the shape consumers (e.g., hotpot) want to write inside a
+    // withContext input callback. Before the fix, both links in the chain
+    // could throw before any microtask had run.
+    expect(() =>
+      writer.withRules({}, {}).audit({
+        afterWrite: () => {
+          /* noop */
+        }
+      })
+    ).not.toThrow()
+  })
+})

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.1-beta.18",
+  "version": "0.7.1-beta.19",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",

--- a/packages/zodvex/src/internal/db.ts
+++ b/packages/zodvex/src/internal/db.ts
@@ -25,27 +25,24 @@ import type {
 import type { GenericId, NumericValue } from 'convex/values'
 import { z } from 'zod'
 import { decodeDoc, encodeDoc, encodePartialDoc } from './codec'
+import {
+  createAuditDatabaseReader,
+  createAuditDatabaseWriter,
+  createRulesDatabaseReader,
+  createRulesDatabaseWriter,
+  installRulesSubclasses
+} from './rules'
 import type { ReaderAuditConfig, WriterAuditConfig, ZodvexRulesConfig } from './ruleTypes'
 import type { ZodTableMap } from './schema'
 import { $ZodObject, $ZodType, $ZodUnion, encode } from './zod-core'
 
-// Lazy import to avoid circular dependency — rules.ts extends classes from this file.
-// The dynamic import() fires after db.ts finishes initializing, so rules.ts can
-// safely extend ZodvexDatabaseReader/Writer. By the time user code calls
-// .withRules() or .audit(), the module is loaded and cached.
-let _rules: typeof import('./rules') | null = null
-const _rulesReady = import('./rules').then(m => {
-  _rules = m
-})
-function getRules(): typeof import('./rules') {
-  if (!_rules) {
-    throw new Error(
-      'zodvex rules module not yet loaded. This usually means .withRules() or .audit() ' +
-        'was called at module scope. Move it inside a function handler.'
-    )
-  }
-  return _rules
-}
+// Note on cycle: rules.ts imports ONLY types from db.ts, so this static import
+// triggers no runtime cycle. rules.ts loads first (its top level has no
+// references to db.ts values), then db.ts declares its base classes, and
+// installRulesSubclasses (called at the end of this file) lets rules.ts
+// build its subclass chain. This replaces a prior `dynamic import()`
+// workaround whose promise could race `.withRules()` / `.audit()` calls
+// made from within `withContext`-style input functions.
 
 // ============================================================================
 // Index builder types — decoded-aware replacements for Convex's IndexRangeBuilder
@@ -551,7 +548,7 @@ export class ZodvexDatabaseReader<
     rules: Record<string, any>,
     config?: ZodvexRulesConfig
   ): ZodvexDatabaseReader<DataModel, DecodedDocs> {
-    return getRules().createRulesDatabaseReader(this, ctx, rules, config)
+    return createRulesDatabaseReader(this, ctx, rules, config)
   }
 
   /**
@@ -560,7 +557,7 @@ export class ZodvexDatabaseReader<
    * with `.withRules()`.
    */
   audit(config: ReaderAuditConfig): ZodvexDatabaseReader<DataModel, DecodedDocs> {
-    return getRules().createAuditDatabaseReader(this, config)
+    return createAuditDatabaseReader(this, config)
   }
 }
 
@@ -726,7 +723,7 @@ export class ZodvexDatabaseWriter<
     rules: Record<string, any>,
     config?: ZodvexRulesConfig
   ): ZodvexDatabaseWriter<DataModel, DecodedDocs> {
-    return getRules().createRulesDatabaseWriter(this, ctx, rules, config)
+    return createRulesDatabaseWriter(this, ctx, rules, config)
   }
 
   /**
@@ -735,7 +732,7 @@ export class ZodvexDatabaseWriter<
    * with `.withRules()`.
    */
   audit(config: WriterAuditConfig): ZodvexDatabaseWriter<DataModel, DecodedDocs> {
-    return getRules().createAuditDatabaseWriter(this, config)
+    return createAuditDatabaseWriter(this, config)
   }
 }
 
@@ -772,3 +769,11 @@ export function createZodDbWriter<
 ): ZodvexDatabaseWriter<DataModel, DD> {
   return new ZodvexDatabaseWriter(db, schema.__zodTableMap) as ZodvexDatabaseWriter<DataModel, DD>
 }
+
+// Wire rules.ts subclasses now that base classes above are fully declared.
+// Safe to run at module scope — synchronous, idempotent, no promises.
+installRulesSubclasses({
+  ZodvexQueryChain,
+  ZodvexDatabaseReader,
+  ZodvexDatabaseWriter
+})

--- a/packages/zodvex/src/internal/rules.ts
+++ b/packages/zodvex/src/internal/rules.ts
@@ -7,7 +7,10 @@ import type {
 } from 'convex/server'
 import type { GenericId } from 'convex/values'
 import { z } from 'zod'
-import { ZodvexDatabaseReader, ZodvexDatabaseWriter, ZodvexQueryChain } from './db'
+// Type-only imports of db.ts classes — no runtime cycle. The actual class
+// references arrive at runtime via installRulesSubclasses() below, which
+// db.ts calls once its base classes are fully declared.
+import type { ZodvexDatabaseReader, ZodvexDatabaseWriter, ZodvexQueryChain } from './db'
 
 export {
   type DeleteRule,
@@ -49,183 +52,688 @@ export function normalizeReadResult<Doc>(
   return result
 }
 
+// ============================================================================
+// Subclass storage + installer
+// ============================================================================
+//
+// The six classes below (Rules* and Audit*) all extend classes declared in
+// db.ts. Declaring them at module top level would force rules.ts to dereference
+// those base classes at its own module-init time — which in turn would force
+// db.ts to run first. But db.ts imports rules.ts, so it cannot. That's the
+// circular dependency.
+//
+// The fix: keep rules.ts top-level free of runtime references to db.ts. All
+// subclass declarations live inside `installRulesSubclasses`, which db.ts
+// calls AFTER its own class declarations are complete. At that point, the
+// base classes are real values and the extends chain resolves correctly.
+//
+// This replaces an earlier `dynamic import()` workaround, which had a timing
+// race: callers that invoked `.withRules()` or `.audit()` synchronously
+// (e.g., inside a `withContext` input function at mutation wire-up time)
+// could hit the guard before the dynamic import resolved.
+
+type Subclasses = {
+  RulesQueryChain: any
+  RulesDatabaseReader: any
+  RulesDatabaseWriter: any
+  AuditQueryChain: any
+  AuditDatabaseReader: any
+  AuditDatabaseWriter: any
+}
+
+let _subclasses: Subclasses | null = null
+
 /**
- * Extends ZodvexQueryChain, applying a read rule at every terminal method.
- * Intermediate methods are inherited from the base class via createChain().
- * Only terminals and createChain() are overridden.
+ * ESM live-binding for test-facing direct construction of `RulesQueryChain`.
+ * Populated by `installRulesSubclasses`. Importers automatically see the
+ * real class after install runs (which happens at db.ts module init).
  */
-export class RulesQueryChain<TableInfo extends GenericTableInfo, Doc> extends ZodvexQueryChain<
-  TableInfo,
-  Doc
-> {
-  private readRule: ReadRule<any, Doc>
-  private rulesConfig: ZodvexRulesConfig
-  private ctx: any
+export let RulesQueryChain: any = null
 
-  constructor(
-    inner: any,
-    schema: any,
-    readRule: ReadRule<any, Doc>,
-    config: ZodvexRulesConfig,
-    ctx: any = {}
-  ) {
-    super(inner, schema)
-    this.readRule = readRule
-    this.rulesConfig = config
-    this.ctx = ctx
+function getSubclasses(): Subclasses {
+  if (!_subclasses) {
+    throw new Error(
+      'zodvex rules subclasses not installed. This usually means the rules module ' +
+        'was loaded without db.ts running its installer. Import zodvex via the ' +
+        'public entry (zodvex/server) so db.ts initializes first.'
+    )
   }
-
-  protected createChain(inner: any): RulesQueryChain<TableInfo, Doc> {
-    return new RulesQueryChain(inner, this.schema, this.readRule, this.rulesConfig, this.ctx)
-  }
-
-  // --- Terminal overrides: apply read rule ---
-
-  async first(): Promise<Doc | null> {
-    for await (const doc of this) {
-      return doc
-    }
-    return null
-  }
-
-  async unique(): Promise<Doc | null> {
-    const doc = await super.unique()
-    if (doc === null) return null
-    return normalizeReadResult(await this.readRule(this.ctx, doc), doc)
-  }
-
-  async collect(): Promise<Doc[]> {
-    const results: Doc[] = []
-    for await (const doc of this) {
-      results.push(doc)
-    }
-    return results
-  }
-
-  async take(n: number): Promise<Doc[]> {
-    const results: Doc[] = []
-    for await (const doc of this) {
-      if (results.length >= n) break
-      results.push(doc)
-    }
-    return results
-  }
-
-  async paginate(opts: PaginationOptions): Promise<PaginationResult<Doc>> {
-    const result = await super.paginate(opts)
-    const filtered: Doc[] = []
-    for (const doc of result.page) {
-      const allowed = normalizeReadResult(await this.readRule(this.ctx, doc), doc)
-      if (allowed !== null) filtered.push(allowed)
-    }
-    return { ...result, page: filtered }
-  }
-
-  async count(): Promise<number> {
-    if (!this.rulesConfig.allowCounting) {
-      throw new Error('count is not allowed with rules')
-    }
-    return super.count()
-  }
-
-  async *[Symbol.asyncIterator](): AsyncIterator<Doc> {
-    const iter = super[Symbol.asyncIterator]()
-    while (true) {
-      const { value, done } = await iter.next()
-      if (done) break
-      const result = normalizeReadResult(await this.readRule(this.ctx, value), value)
-      if (result !== null) yield result
-    }
-  }
+  return _subclasses
 }
 
 /**
- * Wraps a ZodvexDatabaseReader with per-table read rules.
- * Extends ZodvexDatabaseReader so it can be used anywhere a reader is expected,
- * including chained `.withRules()` calls.
- *
- * - `get()` delegates to the inner reader (which decodes), then applies the read rule.
- * - `query()` builds a RulesQueryChain from the raw Convex query + doc schema,
- *   so decoding and rule-checking happen together in the chain's terminal methods.
+ * Called once by db.ts after its base classes are declared. Builds the
+ * Rules*/
+/* and Audit* subclasses with the correct extends chain. Safe to call
+ * multiple times (idempotent).
  */
-class RulesDatabaseReader<
-  DataModel extends GenericDataModel,
-  DecodedDocs extends Record<string, any>
-> extends ZodvexDatabaseReader<DataModel, DecodedDocs> {
-  constructor(
-    private inner: ZodvexDatabaseReader<DataModel, DecodedDocs>,
-    private ctx: any,
-    private rules: Record<string, TableRules<any, any>>,
+export function installRulesSubclasses(bases: {
+  ZodvexQueryChain: typeof ZodvexQueryChain
+  ZodvexDatabaseReader: typeof ZodvexDatabaseReader
+  ZodvexDatabaseWriter: typeof ZodvexDatabaseWriter
+}): void {
+  if (_subclasses) return
+
+  const Base = bases as {
+    ZodvexQueryChain: any
+    ZodvexDatabaseReader: any
+    ZodvexDatabaseWriter: any
+  }
+
+  /**
+   * Extends ZodvexQueryChain, applying a read rule at every terminal method.
+   * Intermediate methods are inherited from the base class via createChain().
+   * Only terminals and createChain() are overridden.
+   */
+  class _RulesQueryChain<TableInfo extends GenericTableInfo, Doc> extends Base.ZodvexQueryChain {
+    private readRule: ReadRule<any, Doc>
     private rulesConfig: ZodvexRulesConfig
-  ) {
-    // Pass the inner's protected db + tableMap to super.
-    const { db, tableMap } = inner._internals
-    super(db, tableMap)
-    this.system = inner.system
-  }
+    private ctx: any
 
-  async get(idOrTable: any, maybeId?: any): Promise<any> {
-    const doc = await this.inner.get(idOrTable, maybeId)
-    if (doc === null) return null
-
-    // Resolve table name for rule lookup
-    const tableName =
-      maybeId !== undefined ? (idOrTable as string) : this.resolveTableFromId(idOrTable)
-
-    if (!tableName) return doc
-    return this.applyReadRule(tableName, doc)
-  }
-
-  query<TableName extends TableNamesInDataModel<DataModel>>(tableName: TableName): any {
-    const tableRules = this.rules[tableName as string]
-
-    if (!tableRules?.read && (this.rulesConfig.defaultPolicy ?? 'allow') === 'allow') {
-      // No rule + allow policy -> delegate to inner (preserves any upstream rules)
-      return this.inner.query(tableName)
+    constructor(
+      inner: any,
+      schema: any,
+      readRule: ReadRule<any, Doc>,
+      config: ZodvexRulesConfig,
+      ctx: any = {}
+    ) {
+      super(inner, schema)
+      this.readRule = readRule
+      this.rulesConfig = config
+      this.ctx = ctx
     }
 
-    // Delegate to inner.query() which returns a decoded (and possibly rule-filtered) chain.
-    // Wrap with a passthrough schema since inner already decoded the docs.
-    const innerChain = this.inner.query(tableName)
-    const readRule = tableRules?.read ?? (async () => null) // deny if no rule + deny policy
-    const passthroughSchema = z.any()
-    return new RulesQueryChain(innerChain, passthroughSchema, readRule, this.rulesConfig, this.ctx)
-  }
+    protected createChain(inner: any): _RulesQueryChain<TableInfo, Doc> {
+      return new _RulesQueryChain(
+        inner,
+        (this as any).schema,
+        this.readRule,
+        this.rulesConfig,
+        this.ctx
+      )
+    }
 
-  // normalizeId requires TableNamesInDataModel but we iterate dynamic string keys — cast required
-  private resolveTableFromId(id: any): string | null {
-    for (const tableName of Object.keys(this.rules)) {
-      if (this.inner.normalizeId(tableName as any, id as unknown as string)) {
-        return tableName
+    async first(): Promise<Doc | null> {
+      for await (const doc of this as any) {
+        return doc
+      }
+      return null
+    }
+
+    async unique(): Promise<Doc | null> {
+      const doc = await super.unique()
+      if (doc === null) return null
+      return normalizeReadResult(await this.readRule(this.ctx, doc), doc)
+    }
+
+    async collect(): Promise<Doc[]> {
+      const results: Doc[] = []
+      for await (const doc of this as any) {
+        results.push(doc)
+      }
+      return results
+    }
+
+    async take(n: number): Promise<Doc[]> {
+      const results: Doc[] = []
+      for await (const doc of this as any) {
+        if (results.length >= n) break
+        results.push(doc)
+      }
+      return results
+    }
+
+    async paginate(opts: PaginationOptions): Promise<PaginationResult<Doc>> {
+      const result = await super.paginate(opts)
+      const filtered: Doc[] = []
+      for (const doc of result.page) {
+        const allowed = normalizeReadResult(await this.readRule(this.ctx, doc), doc)
+        if (allowed !== null) filtered.push(allowed)
+      }
+      return { ...result, page: filtered }
+    }
+
+    async count(): Promise<number> {
+      if (!this.rulesConfig.allowCounting) {
+        throw new Error('count is not allowed with rules')
+      }
+      return super.count()
+    }
+
+    async *[Symbol.asyncIterator](): AsyncIterator<Doc> {
+      const iter = super[Symbol.asyncIterator]()
+      while (true) {
+        const { value, done } = await iter.next()
+        if (done) break
+        const result = normalizeReadResult(await this.readRule(this.ctx, value), value)
+        if (result !== null) yield result
       }
     }
-    // If not found in rules, check ALL tables from tableMap for defaultPolicy: deny
-    if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
-      for (const tableName of Object.keys(this.inner._internals.tableMap)) {
+  }
+
+  /**
+   * Wraps a ZodvexDatabaseReader with per-table read rules.
+   */
+  class _RulesDatabaseReader<
+    DataModel extends GenericDataModel,
+    DecodedDocs extends Record<string, any>
+  > extends Base.ZodvexDatabaseReader {
+    constructor(
+      private inner: ZodvexDatabaseReader<DataModel, DecodedDocs>,
+      private ctx: any,
+      private rules: Record<string, TableRules<any, any>>,
+      private rulesConfig: ZodvexRulesConfig
+    ) {
+      const { db, tableMap } = (inner as any)._internals
+      super(db, tableMap)
+      ;(this as any).system = (inner as any).system
+    }
+
+    async get(idOrTable: any, maybeId?: any): Promise<any> {
+      const doc = await this.inner.get(idOrTable, maybeId)
+      if (doc === null) return null
+
+      const tableName =
+        maybeId !== undefined ? (idOrTable as string) : this.resolveTableFromId(idOrTable)
+
+      if (!tableName) return doc
+      return this.applyReadRule(tableName, doc)
+    }
+
+    query<TableName extends TableNamesInDataModel<DataModel>>(tableName: TableName): any {
+      const tableRules = this.rules[tableName as string]
+
+      if (!tableRules?.read && (this.rulesConfig.defaultPolicy ?? 'allow') === 'allow') {
+        return this.inner.query(tableName)
+      }
+
+      const innerChain = this.inner.query(tableName)
+      const readRule = tableRules?.read ?? (async () => null)
+      const passthroughSchema = z.any()
+      return new _RulesQueryChain(
+        innerChain,
+        passthroughSchema,
+        readRule,
+        this.rulesConfig,
+        this.ctx
+      )
+    }
+
+    private resolveTableFromId(id: any): string | null {
+      for (const tableName of Object.keys(this.rules)) {
         if (this.inner.normalizeId(tableName as any, id as unknown as string)) {
           return tableName
         }
       }
+      if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
+        for (const tableName of Object.keys((this.inner as any)._internals.tableMap)) {
+          if (this.inner.normalizeId(tableName as any, id as unknown as string)) {
+            return tableName
+          }
+        }
+      }
+      return null
     }
-    return null
+
+    private async applyReadRule(tableName: string, doc: any): Promise<any> {
+      const tableRules = this.rules[tableName]
+      if (!tableRules?.read) {
+        if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') return null
+        return doc
+      }
+      const result = await tableRules.read(this.ctx, doc)
+      return normalizeReadResult(result, doc)
+    }
   }
 
-  private async applyReadRule(tableName: string, doc: any): Promise<any> {
-    const tableRules = this.rules[tableName]
-    if (!tableRules?.read) {
-      if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') return null
+  /**
+   * Wraps a ZodvexDatabaseWriter with per-table read and write rules.
+   */
+  class _RulesDatabaseWriter<
+    DataModel extends GenericDataModel,
+    DecodedDocs extends Record<string, any>
+  > extends Base.ZodvexDatabaseWriter {
+    private rulesReader: ZodvexDatabaseReader<DataModel, DecodedDocs>
+
+    constructor(
+      private inner: ZodvexDatabaseWriter<DataModel, DecodedDocs>,
+      private ctx: any,
+      private rules: Record<string, TableRules<any, any>>,
+      private rulesConfig: ZodvexRulesConfig
+    ) {
+      const { db, tableMap, reader: innerReader } = (inner as any)._internals
+      super(db, tableMap)
+      this.rulesReader = new _RulesDatabaseReader(innerReader, ctx, rules, rulesConfig) as any
+      ;(this as any).system = (inner as any).system
+    }
+
+    normalizeId<TableName extends TableNamesInDataModel<DataModel>>(
+      tableName: TableName,
+      id: string
+    ): GenericId<TableName> | null {
+      return this.rulesReader.normalizeId(tableName, id)
+    }
+
+    async get(idOrTable: any, maybeId?: any): Promise<any> {
+      return this.rulesReader.get(idOrTable, maybeId)
+    }
+
+    query<TableName extends TableNamesInDataModel<DataModel>>(tableName: TableName): any {
+      return this.rulesReader.query(tableName)
+    }
+
+    async insert(table: any, value: any): Promise<any> {
+      const tableName = table as string
+      const tableRules = this.rules[tableName]
+
+      if (tableRules?.insert) {
+        const transformed = await tableRules.insert(this.ctx, value)
+        return this.inner.insert(table, transformed)
+      }
+
+      if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
+        throw new Error(`insert not allowed on ${tableName}`)
+      }
+
+      return this.inner.insert(table, value)
+    }
+
+    async patch(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
+      let id: any
+      let value: any
+
+      if (maybeValue !== undefined) {
+        id = idOrValue
+        value = maybeValue
+      } else {
+        id = idOrTable
+        value = idOrValue
+      }
+
+      const doc = await this.rulesReader.get(id)
+      if (doc === null) {
+        throw new Error('no read access or doc does not exist')
+      }
+
+      const tableName = this.resolveTableFromId(id)
+      const tableRules = tableName ? this.rules[tableName] : undefined
+
+      if (tableRules?.patch) {
+        const transformed = await tableRules.patch(this.ctx, doc, value)
+        return this.inner.patch(id, transformed)
+      }
+
+      if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
+        throw new Error(`patch not allowed on ${tableName}`)
+      }
+
+      return this.inner.patch(id, value)
+    }
+
+    async replace(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
+      let id: any
+      let value: any
+
+      if (maybeValue !== undefined) {
+        id = idOrValue
+        value = maybeValue
+      } else {
+        id = idOrTable
+        value = idOrValue
+      }
+
+      const doc = await this.rulesReader.get(id)
+      if (doc === null) {
+        throw new Error('no read access or doc does not exist')
+      }
+
+      const tableName = this.resolveTableFromId(id)
+      const tableRules = tableName ? this.rules[tableName] : undefined
+
+      if (tableRules?.replace) {
+        const transformed = await tableRules.replace(this.ctx, doc, value)
+        return this.inner.replace(id, transformed)
+      }
+
+      if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
+        throw new Error(`replace not allowed on ${tableName}`)
+      }
+
+      return this.inner.replace(id, value)
+    }
+
+    async delete(idOrTable: any, maybeId?: any): Promise<void> {
+      let id: any
+
+      if (maybeId !== undefined) {
+        id = maybeId
+      } else {
+        id = idOrTable
+      }
+
+      const doc = await this.rulesReader.get(id)
+      if (doc === null) {
+        throw new Error('no read access or doc does not exist')
+      }
+
+      const tableName = this.resolveTableFromId(id)
+      const tableRules = tableName ? this.rules[tableName] : undefined
+
+      if (tableRules?.delete) {
+        await tableRules.delete(this.ctx, doc)
+        return this.inner.delete(id)
+      }
+
+      if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
+        throw new Error(`delete not allowed on ${tableName}`)
+      }
+
+      return this.inner.delete(id)
+    }
+
+    private resolveTableFromId(id: any): string | null {
+      for (const tableName of Object.keys(this.rules)) {
+        if (this.inner.normalizeId(tableName as any, id as unknown as string)) {
+          return tableName
+        }
+      }
+      if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
+        for (const tableName of Object.keys((this.inner as any)._internals.tableMap)) {
+          if (this.inner.normalizeId(tableName as any, id as unknown as string)) {
+            return tableName
+          }
+        }
+      }
+      return null
+    }
+  }
+
+  // ==========================================================================
+  // Audit wrapping — afterRead and afterWrite callbacks
+  // ==========================================================================
+
+  /**
+   * Extends ZodvexQueryChain to fire an afterRead callback for each document
+   * returned by terminal methods.
+   */
+  class _AuditQueryChain<TableInfo extends GenericTableInfo, Doc> extends Base.ZodvexQueryChain {
+    private afterRead: (table: string, doc: any) => void | Promise<void>
+    private tableName: string
+
+    constructor(
+      inner: any,
+      schema: any,
+      afterRead: (table: string, doc: any) => void | Promise<void>,
+      tableName: string
+    ) {
+      super(inner, schema)
+      this.afterRead = afterRead
+      this.tableName = tableName
+    }
+
+    protected createChain(inner: any): _AuditQueryChain<TableInfo, Doc> {
+      return new _AuditQueryChain(inner, (this as any).schema, this.afterRead, this.tableName)
+    }
+
+    async first(): Promise<Doc | null> {
+      const doc = await super.first()
+      if (doc !== null) await this.afterRead(this.tableName, doc)
       return doc
     }
-    const result = await tableRules.read(this.ctx, doc)
-    return normalizeReadResult(result, doc)
+
+    async unique(): Promise<Doc | null> {
+      const doc = await super.unique()
+      if (doc !== null) await this.afterRead(this.tableName, doc)
+      return doc
+    }
+
+    async collect(): Promise<Doc[]> {
+      const docs = await super.collect()
+      for (const doc of docs) {
+        await this.afterRead(this.tableName, doc)
+      }
+      return docs
+    }
+
+    async take(n: number): Promise<Doc[]> {
+      const docs = await super.take(n)
+      for (const doc of docs) {
+        await this.afterRead(this.tableName, doc)
+      }
+      return docs
+    }
+
+    async paginate(opts: PaginationOptions): Promise<PaginationResult<Doc>> {
+      const result = await super.paginate(opts)
+      for (const doc of result.page) {
+        await this.afterRead(this.tableName, doc)
+      }
+      return result
+    }
+
+    async *[Symbol.asyncIterator](): AsyncIterator<Doc> {
+      const iter = super[Symbol.asyncIterator]()
+      while (true) {
+        const { value, done } = await iter.next()
+        if (done) break
+        await this.afterRead(this.tableName, value)
+        yield value
+      }
+    }
+  }
+
+  /**
+   * Wraps a ZodvexDatabaseReader with afterRead audit callbacks.
+   */
+  class _AuditDatabaseReader<
+    DataModel extends GenericDataModel,
+    DecodedDocs extends Record<string, any>
+  > extends Base.ZodvexDatabaseReader {
+    private inner: ZodvexDatabaseReader<DataModel, DecodedDocs>
+    private afterRead: (table: string, doc: any) => void | Promise<void>
+
+    constructor(inner: ZodvexDatabaseReader<DataModel, DecodedDocs>, config: ReaderAuditConfig) {
+      const { db, tableMap } = (inner as any)._internals
+      super(db, tableMap)
+      this.inner = inner
+      this.afterRead =
+        config.afterRead ??
+        (() => {
+          /* noop */
+        })
+      ;(this as any).system = (inner as any).system
+    }
+
+    async get(idOrTable: any, maybeId?: any): Promise<any> {
+      const doc = await this.inner.get(idOrTable, maybeId)
+      if (doc !== null) {
+        const tableName = this.resolveTableFromId(
+          maybeId !== undefined ? maybeId : idOrTable,
+          maybeId !== undefined ? idOrTable : undefined
+        )
+        if (tableName) {
+          await this.afterRead(tableName, doc)
+        }
+      }
+      return doc
+    }
+
+    query<TableName extends TableNamesInDataModel<DataModel>>(tableName: TableName): any {
+      const innerChain = this.inner.query(tableName)
+      const passthroughSchema = z.any()
+      return new _AuditQueryChain(
+        innerChain,
+        passthroughSchema,
+        this.afterRead,
+        tableName as string
+      )
+    }
+
+    private resolveTableFromId(id: any, explicitTable?: string): string | null {
+      if (explicitTable) return explicitTable
+      for (const tableName of Object.keys((this as any).tableMap)) {
+        if (this.inner.normalizeId(tableName as any, id as unknown as string)) {
+          return tableName
+        }
+      }
+      return null
+    }
+  }
+
+  /**
+   * Wraps a ZodvexDatabaseWriter with afterRead and afterWrite audit callbacks.
+   */
+  class _AuditDatabaseWriter<
+    DataModel extends GenericDataModel,
+    DecodedDocs extends Record<string, any>
+  > extends Base.ZodvexDatabaseWriter {
+    private inner: ZodvexDatabaseWriter<DataModel, DecodedDocs>
+    private auditReader: ZodvexDatabaseReader<DataModel, DecodedDocs>
+    private afterWrite: ((table: string, event: WriteEvent) => void | Promise<void>) | undefined
+
+    constructor(inner: ZodvexDatabaseWriter<DataModel, DecodedDocs>, config: WriterAuditConfig) {
+      const { db, tableMap, reader: innerReader } = (inner as any)._internals
+      super(db, tableMap)
+      this.inner = inner
+      this.afterWrite = config.afterWrite as typeof this.afterWrite
+
+      this.auditReader = config.afterRead
+        ? (new _AuditDatabaseReader(innerReader, { afterRead: config.afterRead }) as any)
+        : innerReader
+      ;(this as any).system = (inner as any).system
+    }
+
+    normalizeId<TableName extends TableNamesInDataModel<DataModel>>(
+      tableName: TableName,
+      id: string
+    ): GenericId<TableName> | null {
+      return this.auditReader.normalizeId(tableName, id)
+    }
+
+    async get(idOrTable: any, maybeId?: any): Promise<any> {
+      return this.auditReader.get(idOrTable, maybeId)
+    }
+
+    query<TableName extends TableNamesInDataModel<DataModel>>(tableName: TableName): any {
+      return this.auditReader.query(tableName)
+    }
+
+    async insert(table: any, value: any): Promise<any> {
+      const id = await this.inner.insert(table, value)
+      if (this.afterWrite) {
+        await this.afterWrite(table as string, { type: 'insert', id, value })
+      }
+      return id
+    }
+
+    async patch(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
+      let id: any
+      let value: any
+
+      if (maybeValue !== undefined) {
+        id = idOrValue
+        value = maybeValue
+      } else {
+        id = idOrTable
+        value = idOrValue
+      }
+
+      const doc = await this.inner.get(id)
+
+      if (maybeValue !== undefined) {
+        await this.inner.patch(idOrTable, idOrValue, maybeValue)
+      } else {
+        await this.inner.patch(id, value)
+      }
+
+      if (this.afterWrite) {
+        const tableName = this.resolveTableFromId(id)
+        if (tableName) {
+          await this.afterWrite(tableName, { type: 'patch', id, doc, value })
+        }
+      }
+    }
+
+    async replace(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
+      let id: any
+      let value: any
+
+      if (maybeValue !== undefined) {
+        id = idOrValue
+        value = maybeValue
+      } else {
+        id = idOrTable
+        value = idOrValue
+      }
+
+      const doc = await this.inner.get(id)
+
+      if (maybeValue !== undefined) {
+        await this.inner.replace(idOrTable, idOrValue, maybeValue)
+      } else {
+        await this.inner.replace(id, value)
+      }
+
+      if (this.afterWrite) {
+        const tableName = this.resolveTableFromId(id)
+        if (tableName) {
+          await this.afterWrite(tableName, { type: 'replace', id, doc, value })
+        }
+      }
+    }
+
+    async delete(idOrTable: any, maybeId?: any): Promise<void> {
+      let id: any
+
+      if (maybeId !== undefined) {
+        id = maybeId
+      } else {
+        id = idOrTable
+      }
+
+      const doc = await this.inner.get(id)
+
+      if (maybeId !== undefined) {
+        await this.inner.delete(idOrTable, maybeId)
+      } else {
+        await this.inner.delete(id)
+      }
+
+      if (this.afterWrite) {
+        const tableName = this.resolveTableFromId(id)
+        if (tableName) {
+          await this.afterWrite(tableName, { type: 'delete', id, doc })
+        }
+      }
+    }
+
+    private resolveTableFromId(id: any): string | null {
+      for (const tableName of Object.keys((this.inner as any)._internals.tableMap)) {
+        if (this.inner.normalizeId(tableName as any, id as unknown as string)) {
+          return tableName
+        }
+      }
+      return null
+    }
+  }
+
+  // Populate module slots. ESM live-binding updates importers of
+  // `RulesQueryChain` automatically.
+  RulesQueryChain = _RulesQueryChain
+  _subclasses = {
+    RulesQueryChain: _RulesQueryChain,
+    RulesDatabaseReader: _RulesDatabaseReader,
+    RulesDatabaseWriter: _RulesDatabaseWriter,
+    AuditQueryChain: _AuditQueryChain,
+    AuditDatabaseReader: _AuditDatabaseReader,
+    AuditDatabaseWriter: _AuditDatabaseWriter
   }
 }
 
-/**
- * Factory function for creating a RulesDatabaseReader.
- * Breaks the circular dependency between db.ts (which imports this) and rules.ts
- * (which imports ZodvexDatabaseReader from db.ts).
- */
+// ============================================================================
+// Factory functions — public surface called by db.ts methods
+// ============================================================================
+
 export function createRulesDatabaseReader<
   DataModel extends GenericDataModel,
   DecodedDocs extends Record<string, any>
@@ -235,194 +743,9 @@ export function createRulesDatabaseReader<
   rules: Record<string, TableRules<any, any>>,
   config?: ZodvexRulesConfig
 ): ZodvexDatabaseReader<DataModel, DecodedDocs> {
-  return new RulesDatabaseReader(inner, ctx, rules, config ?? {})
+  return new (getSubclasses().RulesDatabaseReader)(inner, ctx, rules, config ?? {})
 }
 
-/**
- * Wraps a ZodvexDatabaseWriter with per-table read and write rules.
- * Extends ZodvexDatabaseWriter so it can be used anywhere a writer is expected.
- *
- * - Read operations (get, query) delegate through an internal RulesDatabaseReader.
- * - Write operations (insert, patch, replace, delete) apply per-operation rules
- *   that can transform values or throw to deny.
- * - Write operations delegate to `this.inner` (the original ZodvexDatabaseWriter),
- *   NOT to `super`. Rules transform decoded values; the inner writer handles encoding.
- */
-class RulesDatabaseWriter<
-  DataModel extends GenericDataModel,
-  DecodedDocs extends Record<string, any>
-> extends ZodvexDatabaseWriter<DataModel, DecodedDocs> {
-  private rulesReader: ZodvexDatabaseReader<DataModel, DecodedDocs>
-
-  constructor(
-    private inner: ZodvexDatabaseWriter<DataModel, DecodedDocs>,
-    private ctx: any,
-    private rules: Record<string, TableRules<any, any>>,
-    private rulesConfig: ZodvexRulesConfig
-  ) {
-    // Pass the inner's protected db + tableMap to super.
-    const { db, tableMap, reader: innerReader } = inner._internals
-    super(db, tableMap)
-    // Build a rules-aware reader from the inner writer's reader for read operations.
-    this.rulesReader = new RulesDatabaseReader(innerReader, ctx, rules, rulesConfig)
-    this.system = inner.system
-  }
-
-  // --- Read methods: delegate through rules-aware reader ---
-
-  normalizeId<TableName extends TableNamesInDataModel<DataModel>>(
-    tableName: TableName,
-    id: string
-  ): GenericId<TableName> | null {
-    return this.rulesReader.normalizeId(tableName, id)
-  }
-
-  async get(idOrTable: any, maybeId?: any): Promise<any> {
-    return this.rulesReader.get(idOrTable, maybeId)
-  }
-
-  query<TableName extends TableNamesInDataModel<DataModel>>(tableName: TableName): any {
-    return this.rulesReader.query(tableName)
-  }
-
-  // --- Write methods: apply rules, then delegate to inner writer ---
-
-  async insert(table: any, value: any): Promise<any> {
-    const tableName = table as string
-    const tableRules = this.rules[tableName]
-
-    if (tableRules?.insert) {
-      const transformed = await tableRules.insert(this.ctx, value)
-      return this.inner.insert(table, transformed)
-    }
-
-    if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
-      throw new Error(`insert not allowed on ${tableName}`)
-    }
-
-    return this.inner.insert(table, value)
-  }
-
-  async patch(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
-    // Resolve arguments: support both patch(id, value) and patch(table, id, value)
-    let id: any
-    let value: any
-
-    if (maybeValue !== undefined) {
-      id = idOrValue
-      value = maybeValue
-    } else {
-      id = idOrTable
-      value = idOrValue
-    }
-
-    // Fetch current doc via rules-aware reader (applies read rules)
-    const doc = await this.rulesReader.get(id)
-    if (doc === null) {
-      throw new Error('no read access or doc does not exist')
-    }
-
-    const tableName = this.resolveTableFromId(id)
-    const tableRules = tableName ? this.rules[tableName] : undefined
-
-    if (tableRules?.patch) {
-      const transformed = await tableRules.patch(this.ctx, doc, value)
-      return this.inner.patch(id, transformed)
-    }
-
-    if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
-      throw new Error(`patch not allowed on ${tableName}`)
-    }
-
-    return this.inner.patch(id, value)
-  }
-
-  async replace(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
-    let id: any
-    let value: any
-
-    if (maybeValue !== undefined) {
-      id = idOrValue
-      value = maybeValue
-    } else {
-      id = idOrTable
-      value = idOrValue
-    }
-
-    // Fetch current doc via rules-aware reader (applies read rules)
-    const doc = await this.rulesReader.get(id)
-    if (doc === null) {
-      throw new Error('no read access or doc does not exist')
-    }
-
-    const tableName = this.resolveTableFromId(id)
-    const tableRules = tableName ? this.rules[tableName] : undefined
-
-    if (tableRules?.replace) {
-      const transformed = await tableRules.replace(this.ctx, doc, value)
-      return this.inner.replace(id, transformed)
-    }
-
-    if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
-      throw new Error(`replace not allowed on ${tableName}`)
-    }
-
-    return this.inner.replace(id, value)
-  }
-
-  async delete(idOrTable: any, maybeId?: any): Promise<void> {
-    let id: any
-
-    if (maybeId !== undefined) {
-      id = maybeId
-    } else {
-      id = idOrTable
-    }
-
-    // Fetch current doc via rules-aware reader (applies read rules)
-    const doc = await this.rulesReader.get(id)
-    if (doc === null) {
-      throw new Error('no read access or doc does not exist')
-    }
-
-    const tableName = this.resolveTableFromId(id)
-    const tableRules = tableName ? this.rules[tableName] : undefined
-
-    if (tableRules?.delete) {
-      await tableRules.delete(this.ctx, doc)
-      return this.inner.delete(id)
-    }
-
-    if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
-      throw new Error(`delete not allowed on ${tableName}`)
-    }
-
-    return this.inner.delete(id)
-  }
-
-  // normalizeId requires TableNamesInDataModel but we iterate dynamic string keys — cast required
-  private resolveTableFromId(id: any): string | null {
-    for (const tableName of Object.keys(this.rules)) {
-      if (this.inner.normalizeId(tableName as any, id as unknown as string)) {
-        return tableName
-      }
-    }
-    // If not found in rules, check ALL tables from tableMap for defaultPolicy: deny
-    if ((this.rulesConfig.defaultPolicy ?? 'allow') === 'deny') {
-      for (const tableName of Object.keys(this.inner._internals.tableMap)) {
-        if (this.inner.normalizeId(tableName as any, id as unknown as string)) {
-          return tableName
-        }
-      }
-    }
-    return null
-  }
-}
-
-/**
- * Factory function for creating a RulesDatabaseWriter.
- * Breaks the circular dependency between db.ts and rules.ts.
- */
 export function createRulesDatabaseWriter<
   DataModel extends GenericDataModel,
   DecodedDocs extends Record<string, any>
@@ -432,164 +755,9 @@ export function createRulesDatabaseWriter<
   rules: Record<string, TableRules<any, any>>,
   config?: ZodvexRulesConfig
 ): ZodvexDatabaseWriter<DataModel, DecodedDocs> {
-  return new RulesDatabaseWriter(inner, ctx, rules, config ?? {})
+  return new (getSubclasses().RulesDatabaseWriter)(inner, ctx, rules, config ?? {})
 }
 
-// ============================================================================
-// Audit wrapping — afterRead and afterWrite callbacks
-// ============================================================================
-
-/**
- * Extends ZodvexQueryChain to fire an afterRead callback for each document
- * returned by terminal methods. Intermediate methods are inherited via
- * createChain(). Only terminals and createChain() are overridden.
- *
- * The tableName is captured at construction so the afterRead callback
- * knows which table each document came from.
- */
-class AuditQueryChain<TableInfo extends GenericTableInfo, Doc> extends ZodvexQueryChain<
-  TableInfo,
-  Doc
-> {
-  private afterRead: (table: string, doc: any) => void | Promise<void>
-  private tableName: string
-
-  constructor(
-    inner: any,
-    schema: any,
-    afterRead: (table: string, doc: any) => void | Promise<void>,
-    tableName: string
-  ) {
-    super(inner, schema)
-    this.afterRead = afterRead
-    this.tableName = tableName
-  }
-
-  protected createChain(inner: any): AuditQueryChain<TableInfo, Doc> {
-    return new AuditQueryChain(inner, this.schema, this.afterRead, this.tableName)
-  }
-
-  // --- Terminal overrides: fire afterRead for each returned doc ---
-
-  async first(): Promise<Doc | null> {
-    const doc = await super.first()
-    if (doc !== null) await this.afterRead(this.tableName, doc)
-    return doc
-  }
-
-  async unique(): Promise<Doc | null> {
-    const doc = await super.unique()
-    if (doc !== null) await this.afterRead(this.tableName, doc)
-    return doc
-  }
-
-  async collect(): Promise<Doc[]> {
-    const docs = await super.collect()
-    for (const doc of docs) {
-      await this.afterRead(this.tableName, doc)
-    }
-    return docs
-  }
-
-  async take(n: number): Promise<Doc[]> {
-    const docs = await super.take(n)
-    for (const doc of docs) {
-      await this.afterRead(this.tableName, doc)
-    }
-    return docs
-  }
-
-  async paginate(opts: PaginationOptions): Promise<PaginationResult<Doc>> {
-    const result = await super.paginate(opts)
-    for (const doc of result.page) {
-      await this.afterRead(this.tableName, doc)
-    }
-    return result
-  }
-
-  // count() passes through — no docs to audit
-
-  async *[Symbol.asyncIterator](): AsyncIterator<Doc> {
-    const iter = super[Symbol.asyncIterator]()
-    while (true) {
-      const { value, done } = await iter.next()
-      if (done) break
-      await this.afterRead(this.tableName, value)
-      yield value
-    }
-  }
-}
-
-/**
- * Wraps a ZodvexDatabaseReader with afterRead audit callbacks.
- * Extends ZodvexDatabaseReader so it can be used anywhere a reader is expected,
- * including chained `.audit()` and `.withRules()` calls.
- *
- * - `get()` delegates to the inner reader, fires afterRead if doc is non-null.
- * - `query()` wraps the inner chain in an AuditQueryChain with a passthrough
- *   schema (inner already decoded).
- */
-class AuditDatabaseReader<
-  DataModel extends GenericDataModel,
-  DecodedDocs extends Record<string, any>
-> extends ZodvexDatabaseReader<DataModel, DecodedDocs> {
-  private inner: ZodvexDatabaseReader<DataModel, DecodedDocs>
-  private afterRead: (table: string, doc: any) => void | Promise<void>
-
-  constructor(inner: ZodvexDatabaseReader<DataModel, DecodedDocs>, config: ReaderAuditConfig) {
-    // Pass the inner's protected db + tableMap to super.
-    const { db, tableMap } = inner._internals
-    super(db, tableMap)
-    this.inner = inner
-    this.afterRead =
-      config.afterRead ??
-      (() => {
-        /* noop */
-      })
-    this.system = inner.system
-  }
-
-  async get(idOrTable: any, maybeId?: any): Promise<any> {
-    const doc = await this.inner.get(idOrTable, maybeId)
-    if (doc !== null) {
-      const tableName = this.resolveTableFromId(
-        maybeId !== undefined ? maybeId : idOrTable,
-        maybeId !== undefined ? idOrTable : undefined
-      )
-      if (tableName) {
-        await this.afterRead(tableName, doc)
-      }
-    }
-    return doc
-  }
-
-  query<TableName extends TableNamesInDataModel<DataModel>>(tableName: TableName): any {
-    const innerChain = this.inner.query(tableName)
-    // Passthrough schema since inner already decoded
-    const passthroughSchema = z.any()
-    return new AuditQueryChain(innerChain, passthroughSchema, this.afterRead, tableName as string)
-  }
-
-  /**
-   * Resolves table name from an ID by trying normalizeId against known tables.
-   * If explicitTable is provided (for the 2-arg get form), use it directly.
-   * normalizeId requires TableNamesInDataModel but we iterate dynamic string keys — cast required.
-   */
-  private resolveTableFromId(id: any, explicitTable?: string): string | null {
-    if (explicitTable) return explicitTable
-    for (const tableName of Object.keys(this.tableMap)) {
-      if (this.inner.normalizeId(tableName as any, id as unknown as string)) {
-        return tableName
-      }
-    }
-    return null
-  }
-}
-
-/**
- * Factory function for creating an AuditDatabaseReader.
- * Called via deferred require() from ZodvexDatabaseReader.audit() in db.ts.
- */
 export function createAuditDatabaseReader<
   DataModel extends GenericDataModel,
   DecodedDocs extends Record<string, any>
@@ -597,172 +765,9 @@ export function createAuditDatabaseReader<
   inner: ZodvexDatabaseReader<DataModel, DecodedDocs>,
   config: ReaderAuditConfig
 ): ZodvexDatabaseReader<DataModel, DecodedDocs> {
-  return new AuditDatabaseReader(inner, config)
+  return new (getSubclasses().AuditDatabaseReader)(inner, config)
 }
 
-/**
- * Wraps a ZodvexDatabaseWriter with afterRead and afterWrite audit callbacks.
- * Extends ZodvexDatabaseWriter so it can be used anywhere a writer is expected.
- *
- * - Read operations delegate through an internal AuditDatabaseReader for afterRead.
- * - Write operations delegate to `this.inner` (not super) so encoding happens via
- *   the original writer. Audit observes decoded values (pre-encoding).
- * - For patch/replace/delete, the current doc is fetched via `this.inner.get()` (not the
- *   audited reader) to avoid audit-of-audit recursion for reads triggered by writes.
- */
-class AuditDatabaseWriter<
-  DataModel extends GenericDataModel,
-  DecodedDocs extends Record<string, any>
-> extends ZodvexDatabaseWriter<DataModel, DecodedDocs> {
-  private inner: ZodvexDatabaseWriter<DataModel, DecodedDocs>
-  private auditReader: ZodvexDatabaseReader<DataModel, DecodedDocs>
-  private afterWrite: ((table: string, event: WriteEvent) => void | Promise<void>) | undefined
-
-  constructor(inner: ZodvexDatabaseWriter<DataModel, DecodedDocs>, config: WriterAuditConfig) {
-    // Pass the inner's protected db + tableMap to super.
-    const { db, tableMap, reader: innerReader } = inner._internals
-    super(db, tableMap)
-    this.inner = inner
-    // Generic WriterAuditConfig.afterWrite signature widens to string-keyed dispatch internally
-    this.afterWrite = config.afterWrite as typeof this.afterWrite
-
-    // Build an audit-aware reader from the inner writer's reader for read operations.
-    this.auditReader = config.afterRead
-      ? new AuditDatabaseReader(innerReader, { afterRead: config.afterRead })
-      : innerReader
-    this.system = inner.system
-  }
-
-  // --- Read methods: delegate through audit-aware reader ---
-
-  normalizeId<TableName extends TableNamesInDataModel<DataModel>>(
-    tableName: TableName,
-    id: string
-  ): GenericId<TableName> | null {
-    return this.auditReader.normalizeId(tableName, id)
-  }
-
-  async get(idOrTable: any, maybeId?: any): Promise<any> {
-    return this.auditReader.get(idOrTable, maybeId)
-  }
-
-  query<TableName extends TableNamesInDataModel<DataModel>>(tableName: TableName): any {
-    return this.auditReader.query(tableName)
-  }
-
-  // --- Write methods: delegate to inner, then fire afterWrite ---
-
-  async insert(table: any, value: any): Promise<any> {
-    const id = await this.inner.insert(table, value)
-    if (this.afterWrite) {
-      await this.afterWrite(table as string, { type: 'insert', id, value })
-    }
-    return id
-  }
-
-  async patch(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
-    // Resolve arguments
-    let id: any
-    let value: any
-
-    if (maybeValue !== undefined) {
-      id = idOrValue
-      value = maybeValue
-    } else {
-      id = idOrTable
-      value = idOrValue
-    }
-
-    // Fetch current doc via inner (not audited) to avoid audit recursion
-    const doc = await this.inner.get(id)
-
-    // Delegate the actual write to inner
-    if (maybeValue !== undefined) {
-      await this.inner.patch(idOrTable, idOrValue, maybeValue)
-    } else {
-      await this.inner.patch(id, value)
-    }
-
-    if (this.afterWrite) {
-      const tableName = this.resolveTableFromId(id)
-      if (tableName) {
-        await this.afterWrite(tableName, { type: 'patch', id, doc, value })
-      }
-    }
-  }
-
-  async replace(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
-    let id: any
-    let value: any
-
-    if (maybeValue !== undefined) {
-      id = idOrValue
-      value = maybeValue
-    } else {
-      id = idOrTable
-      value = idOrValue
-    }
-
-    // Fetch current doc via inner to avoid audit recursion
-    const doc = await this.inner.get(id)
-
-    // Delegate the actual write to inner
-    if (maybeValue !== undefined) {
-      await this.inner.replace(idOrTable, idOrValue, maybeValue)
-    } else {
-      await this.inner.replace(id, value)
-    }
-
-    if (this.afterWrite) {
-      const tableName = this.resolveTableFromId(id)
-      if (tableName) {
-        await this.afterWrite(tableName, { type: 'replace', id, doc, value })
-      }
-    }
-  }
-
-  async delete(idOrTable: any, maybeId?: any): Promise<void> {
-    let id: any
-
-    if (maybeId !== undefined) {
-      id = maybeId
-    } else {
-      id = idOrTable
-    }
-
-    // Fetch current doc via inner to avoid audit recursion
-    const doc = await this.inner.get(id)
-
-    // Delegate the actual delete to inner
-    if (maybeId !== undefined) {
-      await this.inner.delete(idOrTable, maybeId)
-    } else {
-      await this.inner.delete(id)
-    }
-
-    if (this.afterWrite) {
-      const tableName = this.resolveTableFromId(id)
-      if (tableName) {
-        await this.afterWrite(tableName, { type: 'delete', id, doc })
-      }
-    }
-  }
-
-  // normalizeId requires TableNamesInDataModel but we iterate dynamic string keys — cast required
-  private resolveTableFromId(id: any): string | null {
-    for (const tableName of Object.keys(this.inner._internals.tableMap)) {
-      if (this.inner.normalizeId(tableName as any, id as unknown as string)) {
-        return tableName
-      }
-    }
-    return null
-  }
-}
-
-/**
- * Factory function for creating an AuditDatabaseWriter.
- * Called from ZodvexDatabaseWriter.audit() in db.ts.
- */
 export function createAuditDatabaseWriter<
   DataModel extends GenericDataModel,
   DecodedDocs extends Record<string, any>
@@ -770,5 +775,5 @@ export function createAuditDatabaseWriter<
   inner: ZodvexDatabaseWriter<DataModel, DecodedDocs>,
   config: WriterAuditConfig
 ): ZodvexDatabaseWriter<DataModel, DecodedDocs> {
-  return new AuditDatabaseWriter(inner, config)
+  return new (getSubclasses().AuditDatabaseWriter)(inner, config)
 }


### PR DESCRIPTION
## Summary

Fixes the lazy-load race that forced consumers into Proxy workarounds when using \`.audit()\` / \`.withRules()\` inside \`withContext\`-style input functions. Hotpot's \`internalMutations.ts\` has a TODO pointing directly at this: the zodvex rules module was loaded via \`dynamic import()\` (to break a module cycle), and the resulting promise could still be unsettled when consumer code tried to call \`.audit()\` during mutation registration — throwing *\"zodvex rules module not yet loaded\"*.

Replaces #58. That PR proposed a new \`beforeWrite\` hook; review found the real blocker was this load race, not a missing primitive. With the race fixed, hotpot's retention-injection case collapses into existing \`.withRules(ctx, { ... insert transforms ... }).audit({ afterWrite })\` — no new API.

## What changed

The circular dependency was: \`rules.ts\` subclassed base classes from \`db.ts\`, and \`db.ts\` needed \`rules.ts\` factories to implement \`.withRules()\` / \`.audit()\`. The old workaround was a top-level \`import('./rules')\` in db.ts with a \`getRules()\` guard — async, raceable.

The new structure:

- **\`rules.ts\`** now only \`import type\`s from \`db.ts\` — zero runtime references at module top level.
- All \`class X extends Y\` declarations move inside \`installRulesSubclasses(bases)\`, which receives the base classes and populates module-level slots.
- **\`db.ts\`** imports \`rules.ts\` statically, declares its base classes, then at the end of its module body calls \`installRulesSubclasses\` with the now-live bases.
- Factory functions (\`createRulesDatabaseReader\`, etc.) read from the populated slots. No promise. No race.
- \`RulesQueryChain\` stays directly constructable for tests via an ESM \`let\` binding that the installer updates (live-binding).

## Why this is safe

- No public API change. \`.withRules()\` and \`.audit()\` behave identically.
- The cycle resolves synchronously: rules.ts finishes loading before db.ts declares anything, because its top level now has no extends statements.
- \`installRulesSubclasses\` is idempotent.

## Test plan

- [x] \`bun run test\` — 1954 tests pass (128 pre-existing rules tests + 10 new synchronous-install regression tests across zod + zod-mini)
- [x] \`bun run type-check\` — clean
- [x] \`bun run lint\` — clean (only pre-existing warnings in unrelated files)
- [x] New test file \`rules-synchronous-install.test.ts\` pins down the regression: constructs a writer and calls \`.audit()\` / \`.withRules()\` as the first statement after import, which would have thrown under the old scheme

## For downstream (hotpot)

Once this lands, the entire Proxy in \`convex/hotpot/internalMutations.ts\` can be replaced with:

\`\`\`ts
ctx: {
  ...ctx,
  db: ctx.db
    .withRules(securityCtx, { /* per-table insert transforms, no gates */ })
    .audit({ afterWrite: /* existing audit dispatcher */ })
}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)