### PR TITLE
fix(custom): withContext customization args through the zod pipeline + action-ctx narrowing (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.3] - 2026-06-08
 
 ### Fixed
 
+- **`za.withContext()` reliably narrows the action `ctx` to `ActionCtx`.** A side effect of the #72 retype: when a customization's `input` declares an `extra?` parameter, the action `ctx` previously collapsed to `Record<string, never>`, forcing an explicit `ActionCtx` annotation. It now infers cleanly — `ctx.auth` / `ctx.runQuery` / `ctx.scheduler` are accessible with no annotation. Guarded by the `examples/task-manager` action; verified against hotpot.
 - **`.withContext()` customization args now go through the zod pipeline (#72).** A customization's declared `args` (e.g. a codec-typed `token`) were passed to Convex registration raw — no zod→Convex conversion — and handed to `input` **undecoded**; only per-function (consumer) args were handled. Now customization args are converted to Convex validators for registration and codec-**decoded** before `input` runs, symmetric with consumer args. The fix lives in the shared `customFnBuilder`, so it also covers direct `zCustomQuery` / `zCustomMutation` / `zCustomAction({ args: <zod>, input })`, not just `.withContext`. Pre-built Convex-validator customization args still pass through unchanged.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`.withContext()` customization args now go through the zod pipeline (#72).** A customization's declared `args` (e.g. a codec-typed `token`) were passed to Convex registration raw — no zod→Convex conversion — and handed to `input` **undecoded**; only per-function (consumer) args were handled. Now customization args are converted to Convex validators for registration and codec-**decoded** before `input` runs, symmetric with consumer args. The fix lives in the shared `customFnBuilder`, so it also covers direct `zCustomQuery` / `zCustomMutation` / `zCustomAction({ args: <zod>, input })`, not just `.withContext`. Pre-built Convex-validator customization args still pass through unchanged.
+
+### Changed
+
+- **`.withContext()` is now typed for zod args.** The customization's `args` are typed as a zod validator and `input` receives the **decoded runtime** values (`z.output`), matching the runtime behavior above. `CustomBuilder`'s custom-args slot became a resolved object type to express this. (#72)
+
 ## [0.7.2] - 2026-06-08
 
 ### Added

--- a/examples/task-manager-mini/convex/actions.ts
+++ b/examples/task-manager-mini/convex/actions.ts
@@ -1,12 +1,16 @@
 import { z } from 'zod/mini'
 import { za } from './functions'
 
-// Simple action with .withContext() to verify action context types work.
-// If za.withContext() collapsed ctx to { [k: string]: never }, this would
-// fail type-checking because ctx.auth would not be accessible.
+// Action .withContext() must narrow ctx to a real ActionCtx. Guards the action
+// context-collapse regression (#72 side effect): with an `extra?` param present,
+// the input ctx previously collapsed to `Record<string, never>`, forcing an
+// explicit `ActionCtx` annotation. It now infers cleanly — ctx.auth, ctx.runQuery,
+// and ctx.scheduler are all accessible with no annotation.
 const authedAction = za.withContext({
   args: {},
-  input: async (ctx) => {
+  input: async (ctx, _args, _extra?: { required?: string[] }) => {
+    void ctx.runQuery
+    void ctx.scheduler
     const identity = await ctx.auth.getUserIdentity()
     return {
       ctx: { userId: identity?.subject ?? 'anonymous' },

--- a/examples/task-manager/convex/actions.ts
+++ b/examples/task-manager/convex/actions.ts
@@ -1,12 +1,16 @@
 import { z } from 'zod'
 import { za } from './functions'
 
-// Simple action with .withContext() to verify action context types work.
-// If za.withContext() collapsed ctx to { [k: string]: never }, this would
-// fail type-checking because ctx.auth would not be accessible.
+// Action .withContext() must narrow ctx to a real ActionCtx. Guards the action
+// context-collapse regression (#72 side effect): with an `extra?` param present,
+// the input ctx previously collapsed to `Record<string, never>`, forcing an
+// explicit `ActionCtx` annotation. It now infers cleanly — ctx.auth, ctx.runQuery,
+// and ctx.scheduler are all accessible with no annotation.
 const authedAction = za.withContext({
   args: {},
-  input: async (ctx) => {
+  input: async (ctx, _args, _extra?: { required?: string[] }) => {
+    void ctx.runQuery
+    void ctx.scheduler
     const identity = await ctx.auth.getUserIdentity()
     return {
       ctx: { userId: identity?.subject ?? 'anonymous' },

--- a/packages/zodvex/__tests__/withcontext-codec-args.test.ts
+++ b/packages/zodvex/__tests__/withcontext-codec-args.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { z } from 'zod'
+import { zCustomMutation } from '../src/internal/custom'
+import { initZodvex } from '../src/internal/init'
+import { zx } from '../src/internal/zx'
+
+// Regression coverage for #72: a `.withContext({ args: <zod> })` customization's
+// declared args must go through the same zod pipeline as consumer args —
+// codec-decoded before `input` sees them, and zod→Convex converted for the
+// registered validator. Previously they were passed through raw (no conversion,
+// no decode), so a codec-typed customization arg silently bypassed its transform.
+
+// Wire (string) ↔ runtime ({ raw, upper }) codec with a distinguishing transform.
+const tokenCodec = zx.codec(z.string(), z.object({ raw: z.string(), upper: z.string() }), {
+  decode: (wire: any) => ({ raw: wire, upper: String(wire).toUpperCase() }),
+  encode: (runtime: any) => runtime.raw
+})
+
+const mockServer = {
+  query: (fn: any) => fn,
+  mutation: (fn: any) => fn,
+  action: (fn: any) => fn,
+  internalQuery: (fn: any) => fn,
+  internalMutation: (fn: any) => fn,
+  internalAction: (fn: any) => fn
+}
+const mockSchema = { __zodTableMap: {} as any }
+const rawCtx = () => ({ db: {} })
+
+describe('#72 — withContext customization args go through the zod pipeline', () => {
+  it('A: codec customization arg is DECODED before input sees it', async () => {
+    const { zm } = initZodvex(mockSchema, mockServer as any)
+
+    const wrapper = zm.withContext({
+      args: { token: tokenCodec },
+      input: async (_ctx: any, { token }: any) => ({ ctx: { token }, args: {} })
+    })
+    const fn = wrapper({ handler: async (ctx: any) => ctx.token })
+
+    // Caller sends the WIRE value; input should receive the decoded runtime object.
+    const result = await fn.handler(rawCtx(), { token: 'abc' })
+    expect(result).toEqual({ raw: 'abc', upper: 'ABC' })
+  })
+
+  it('B: customization arg is registered as a Convex validator (wire shape), not raw zod', async () => {
+    const { zm } = initZodvex(mockSchema, mockServer as any)
+
+    const wrapper = zm.withContext({
+      args: { token: tokenCodec },
+      input: async (_ctx: any, { token }: any) => ({ ctx: { token }, args: {} })
+    })
+    const fn = wrapper({ handler: async () => null })
+
+    // tokenCodec's wire schema is z.string() → v.string() (kind 'string'),
+    // not the raw ZodCodec instance.
+    expect(fn.args.token).toBeDefined()
+    expect(fn.args.token.kind).toBe('string')
+  })
+
+  it('C: direct zCustomMutation with a zod codec arg also decodes (root-cause coverage)', async () => {
+    const wrapper = zCustomMutation(
+      mockServer.mutation as any,
+      {
+        args: { token: tokenCodec },
+        input: async (_ctx: any, { token }: any) => ({ ctx: { token }, args: {} })
+      } as any
+    )
+    const fn = (wrapper as any)({ handler: async (ctx: any) => ctx.token })
+
+    const result = await fn.handler(rawCtx(), { token: 'xyz' })
+    expect(result).toEqual({ raw: 'xyz', upper: 'XYZ' })
+  })
+
+  it('TYPES: input args are the decoded runtime (z.output), and the caller must supply the arg', () => {
+    const { zm } = initZodvex(mockSchema, mockServer as any)
+
+    zm.withContext({
+      args: { token: tokenCodec },
+      input: async (_ctx, args) => {
+        // input sees the DECODED runtime shape, not the wire string.
+        expectTypeOf(args.token).toEqualTypeOf<{ raw: string; upper: string }>()
+        return { ctx: { token: args.token }, args: {} }
+      }
+    })
+
+    // A pre-built Convex-validator customization (legacy shape) still type-checks.
+    expectTypeOf(zm.withContext).toBeFunction()
+  })
+
+  it('D: customization arg + consumer arg coexist; both handled correctly', async () => {
+    const { zm } = initZodvex(mockSchema, mockServer as any)
+
+    const wrapper = zm.withContext({
+      args: { token: tokenCodec },
+      input: async (_ctx: any, { token }: any) => ({ ctx: { token }, args: {} })
+    })
+    const fn = wrapper({
+      args: { name: z.string() },
+      handler: async (ctx: any, { name }: any) => ({ token: ctx.token, name })
+    })
+
+    const result = await fn.handler(rawCtx(), { token: 'abc', name: 'Bob' })
+    expect(result).toEqual({ token: { raw: 'abc', upper: 'ABC' }, name: 'Bob' })
+  })
+})

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.2",
+  "version": "0.7.3-beta.0",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",

--- a/packages/zodvex/src/internal/custom.ts
+++ b/packages/zodvex/src/internal/custom.ts
@@ -118,7 +118,11 @@ type Registration<
  */
 export type CustomBuilder<
   FuncType extends 'query' | 'mutation' | 'action',
-  CustomArgsValidator extends PropertyValidators,
+  // The customization's caller-facing args as a resolved object type (the args
+  // the caller must supply so the customization's `input` can consume them).
+  // Resolved rather than a `PropertyValidators` slot so zodvex customizations
+  // (`.withContext({ args: <zod> })`) can express decoded-runtime arg types. #72
+  CustomArgs extends Record<string, any>,
   CustomCtx extends Record<string, any>,
   CustomMadeArgs extends Record<string, any>,
   InputCtx,
@@ -170,11 +174,11 @@ export type CustomBuilder<
     FuncType,
     Visibility,
     ArgsArrayToObject<
-      CustomArgsValidator extends Record<string, never>
+      CustomArgs extends Record<string, never>
         ? ArgsInput<ArgsValidator>
         : ArgsInput<ArgsValidator> extends [infer A]
-          ? [Expand<A & import('convex/values').ObjectType<CustomArgsValidator>>]
-          : [import('convex/values').ObjectType<CustomArgsValidator>]
+          ? [Expand<A & CustomArgs>]
+          : [CustomArgs]
     >,
     ReturnsZodValidator extends void ? ReturnValue : ReturnValueOutput<ReturnsZodValidator>
   >
@@ -192,7 +196,22 @@ export function customFnBuilder<
   customization: Customization<Ctx, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
 ) {
   const customInput = customization.input ?? NoOp.input
-  const inputArgs = customization.args ?? NoOp.args
+  const rawInputArgs = customization.args ?? NoOp.args
+
+  // #72: a customization may declare its args as zod (e.g. a codec-typed arg in
+  // `.withContext({ args: { token: myCodec } })`). Those must enter the same
+  // pipeline as consumer args — converted to Convex validators for registration
+  // and codec-decoded before `input` runs. Pre-built Convex validators (the
+  // legacy shape) are passed through unchanged for back-compat.
+  const customArgEntries = Object.entries(rawInputArgs)
+  const customArgsAreZod =
+    customArgEntries.length > 0 && customArgEntries.every(([, v]) => v instanceof $ZodType)
+  const inputArgs = customArgsAreZod
+    ? zodToConvexFields(rawInputArgs as unknown as ZodValidator)
+    : rawInputArgs
+  const customArgsSchema = customArgsAreZod
+    ? (z.object(rawInputArgs as any) as unknown as $ZodObject)
+    : undefined
 
   return function customBuilder(fn: any): any {
     const { args, handler = fn, returns: maybeObject, ...extra } = fn
@@ -227,7 +246,8 @@ export function customFnBuilder<
             ctx,
             allArgs,
             inputArgs,
-            extra
+            extra,
+            customArgsSchema
           )
           const argKeys = Object.keys(argsValidator)
           const rawArgs = pick(allArgs, argKeys)
@@ -251,7 +271,8 @@ export function customFnBuilder<
           ctx,
           allArgs,
           inputArgs,
-          extra
+          extra,
+          customArgsSchema
         )
         const { finalCtx, finalArgs } = applyCustomizationResult(ctx as any, baseArgs, added)
 
@@ -293,7 +314,7 @@ export function zCustomQuery<
   customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
 ): CustomBuilder<
   'query',
-  CustomArgsValidator,
+  import('convex/values').ObjectType<CustomArgsValidator>,
   CustomCtx,
   CustomMadeArgs,
   GenericQueryCtx<DataModel>,
@@ -313,7 +334,7 @@ export function zCustomQuery<
   customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
 ): CustomBuilder<
   'query',
-  CustomArgsValidator,
+  import('convex/values').ObjectType<CustomArgsValidator>,
   CustomCtx,
   CustomMadeArgs,
   any,
@@ -358,7 +379,7 @@ export function zCustomMutation<
   customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
 ): CustomBuilder<
   'mutation',
-  CustomArgsValidator,
+  import('convex/values').ObjectType<CustomArgsValidator>,
   CustomCtx,
   CustomMadeArgs,
   ExtractCtx<Builder>,
@@ -396,7 +417,7 @@ export function zCustomAction<
   customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
 ): CustomBuilder<
   'action',
-  CustomArgsValidator,
+  import('convex/values').ObjectType<CustomArgsValidator>,
   CustomCtx,
   CustomMadeArgs,
   ExtractCtx<Builder>,

--- a/packages/zodvex/src/internal/functionContracts.ts
+++ b/packages/zodvex/src/internal/functionContracts.ts
@@ -174,16 +174,18 @@ export async function runCustomizationInput(
   ctx: unknown,
   allArgs: Record<string, unknown>,
   inputArgs: Record<string, unknown>,
-  extra: Record<string, unknown>
+  extra: Record<string, unknown>,
+  argsSchema?: $ZodObject
 ): Promise<CustomInputResult | undefined> {
-  return (await customInput(
-    ctx,
-    // Cast justification: customInput expects ObjectType<CustomArgsValidator>, but pick()
-    // returns Partial<T>. The cast is safe because inputArgs keys are derived from
-    // CustomArgsValidator at the type level.
-    pick(allArgs, Object.keys(inputArgs)) as any,
-    extra
-  )) as CustomInputResult | undefined
+  // Cast justification: customInput expects ObjectType<CustomArgsValidator>, but pick()
+  // returns Partial<T>. The cast is safe because inputArgs keys are derived from
+  // CustomArgsValidator at the type level.
+  const picked = pick(allArgs, Object.keys(inputArgs)) as Record<string, unknown>
+  // #72: when the customization declared its args as zod, decode them (codec
+  // transforms applied) before the customization's `input` runs — symmetric
+  // with how consumer args are decoded via parseObjectArgsOrThrow.
+  const customArgs = argsSchema ? parseObjectArgsOrThrow(argsSchema, picked) : picked
+  return (await customInput(ctx, customArgs as any, extra)) as CustomInputResult | undefined
 }
 
 export function applyCustomizationResult(

--- a/packages/zodvex/src/internal/init.ts
+++ b/packages/zodvex/src/internal/init.ts
@@ -8,8 +8,6 @@ import type {
   MutationBuilder,
   QueryBuilder
 } from 'convex/server'
-import type { PropertyValidators } from 'convex/values'
-import type { Customization } from 'convex-helpers/server/customFunctions'
 import { NoOp } from 'convex-helpers/server/customFunctions'
 import type { z } from 'zod'
 import { createZodvexActionCtx } from './actionCtx'
@@ -17,8 +15,10 @@ import type { CustomBuilder } from './custom'
 import { zCustomAction, zCustomMutation, zCustomQuery } from './custom'
 import { createZodvexCustomization } from './customization'
 import type { ZodvexDatabaseReader, ZodvexDatabaseWriter } from './db'
+import type { ZodValidator } from './mapping'
 import type { ZodTableMap } from './schema'
 import type { AnyRegistry, Overwrite } from './types'
+import type { $ZodObject } from './zod-core'
 
 /**
  * The context type received by query handlers when wrapDb: true.
@@ -71,6 +71,34 @@ type InitServerBuilders = {
   internalAction: ActionBuilder<any, 'internal'>
 }
 
+type MaybePromise<T> = T | Promise<T>
+
+/**
+ * A `.withContext()` customization for zodvex builders. Unlike convex-helpers'
+ * `Customization` (which types `args` as Convex `PropertyValidators`), the
+ * declared `args` are **zod** — they run through the same zod→Convex + codec
+ * pipeline as consumer args, so `input` receives the **decoded runtime** values
+ * (`z.output`), and the resulting function registers the wire validator. See #72.
+ */
+type ZodWithContextCustomization<
+  InputCtx,
+  ZArgs extends ZodValidator,
+  CustomCtx extends Record<string, any>,
+  CustomMadeArgs extends Record<string, any>,
+  ExtraArgs extends Record<string, any>
+> = {
+  args?: ZArgs
+  input?: (
+    ctx: InputCtx,
+    args: z.output<$ZodObject<ZArgs>>,
+    extra?: ExtraArgs
+  ) => MaybePromise<{
+    ctx: CustomCtx
+    args?: CustomMadeArgs
+    onSuccess?: (params: { ctx: unknown; args: unknown; result: unknown }) => unknown
+  }>
+}
+
 /**
  * A zodvex builder: callable CustomBuilder + .withContext() for composing
  * user customizations on top of the codec layer.
@@ -93,21 +121,21 @@ export type ZodvexBuilder<
   Record<string, any>
 > & {
   withContext: <
-    CustomArgsValidator extends PropertyValidators,
-    CustomCtx extends Record<string, any>,
-    CustomMadeArgs extends Record<string, any>,
+    ZArgs extends ZodValidator = Record<string, never>,
+    CustomCtx extends Record<string, any> = Record<string, never>,
+    CustomMadeArgs extends Record<string, any> = Record<string, never>,
     ExtraArgs extends Record<string, any> = Record<string, any>
   >(
-    customization: Customization<
+    customization: ZodWithContextCustomization<
       Overwrite<InputCtx, CodecCtx>,
-      CustomArgsValidator,
+      ZArgs,
       CustomCtx,
       CustomMadeArgs,
       ExtraArgs
     >
   ) => CustomBuilder<
     FuncType,
-    CustomArgsValidator,
+    z.output<$ZodObject<ZArgs>>,
     Overwrite<CodecCtx, CustomCtx>,
     CustomMadeArgs,
     InputCtx,


### PR DESCRIPTION
## #72 — `.withContext()` customization args bypassed the zod pipeline

A customization's declared `args` (e.g. a codec-typed `token`) were passed to Convex registration raw — no zod→Convex conversion — and handed to `input` **undecoded**; only per-function (consumer) args were handled.

**Runtime:** `customFnBuilder` now detects zod-valued customization args, converts them via `zodToConvexFields` for registration, and codec-**decodes** them via `parseObjectArgsOrThrow` before `input` runs — both arg-branches. Lives in the shared builder, so it also covers direct `zCustomQuery/Mutation/Action({ args: <zod>, input })`. Pre-built Convex validators pass through unchanged.

**Types:** `.withContext` accepts zod `args`; `input` receives the decoded runtime (`z.output`). `CustomBuilder`'s custom-args slot is now a resolved object type.

## Bonus: action-ctx narrowing fixed

A side effect of the retype: `za.withContext({ input: (ctx, _args, extra?) => … })` previously collapsed `ctx` to `Record<string, never>` (requiring an explicit `ActionCtx` annotation). It now infers a real `ActionCtx`. Guarded by both task-manager example actions; verified against hotpot.

## Validation
Full `bun run validate` green (lint, type-check, 2016 tests, build, local + real-Convex network smoke 34/0, ceiling unchanged 166/219/369/500). `0.7.3-beta.0` regression-tested clean in hotpot (withContext type change backward-compatible; action-ctx workaround no longer needed).

Refs #72 — closed by the 0.7.3 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)