### PR TITLE
feat: cross-function codec auto-encode + full client parity (0.7.5-beta.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ zodvex includes an optional CLI that generates typed client code:
 
 - **Typed hooks** — `useZodQuery`, `useZodMutation` with automatic codec decode
 - **Boundary helpers** — `encodeArgs`, `decodeResult` for custom client integrations
-- **Action auto-decode** — `ctx.runQuery` / `ctx.runMutation` decode via registry
+- **Cross-function auto-codec** — `ctx.runQuery` / `ctx.runMutation` encode args + decode results, and `ctx.scheduler.runAfter` / `ctx.scheduler.runAt` encode args, via the registry. Pass natural decoded values; zodvex encodes them to wire at the call site.
 
 ```bash
 zodvex generate   # one-shot generation

--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
     },
     "packages/zodvex": {
       "name": "zodvex",
-      "version": "0.7.4",
+      "version": "0.7.5-beta.0",
       "bin": {
         "zodvex": "./dist/cli/index.js",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,7 @@
     },
     "packages/zodvex": {
       "name": "zodvex",
-      "version": "0.7.2-beta.0",
+      "version": "0.7.4",
       "bin": {
         "zodvex": "./dist/cli/index.js",
       },

--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -20,7 +20,7 @@ zodvex includes a code generator that introspects your Convex directory at build
 
 **You DO need codegen for:**
 - Typed React hooks that encode args and decode results automatically
-- `ctx.runQuery` / `ctx.runMutation` in actions that decode results via the registry
+- `ctx.runQuery` / `ctx.runMutation` and `ctx.scheduler.runAfter` / `runAt` that auto-encode codec args (and decode results) via the registry
 - Sharing Zod schemas between server and client without importing server-only modules
 
 ## Setup
@@ -58,7 +58,7 @@ convex/_zodvex/
 
 ## Registry wiring
 
-The generated `_zodvex/api.js` exports a `zodvexRegistry` — a plain object mapping every public function path to its `args` and `returns` Zod schemas. Wire it into `initZodvex` via the `registry` option so actions can auto-decode `runQuery` / `runMutation` results:
+The generated `_zodvex/api.js` exports a `zodvexRegistry` — a plain object mapping every public function path to its `args` and `returns` Zod schemas. Wire it into `initZodvex` via the `registry` option so `runQuery` / `runMutation` / `scheduler.runAfter` / `scheduler.runAt` auto-encode codec args (and decode results):
 
 ```typescript
 // convex/functions.ts
@@ -81,7 +81,7 @@ export const { zq, zm, za, ziq, zim, zia } = initZodvex(schema, {
 
 The `registry` option is a thunk (`() => zodvexRegistry`) to avoid a circular-import issue: `functions.ts` is itself discovered during codegen, so it imports from `_zodvex/api.js` at runtime rather than at module evaluation time.
 
-When the registry is provided, `za` and `zia` replace `ctx.runQuery` and `ctx.runMutation` with codec-aware versions that automatically decode results using the registry's `returns` schema.
+When the registry is provided, `za` and `zia` replace `ctx.runQuery` and `ctx.runMutation` with codec-aware versions that **encode args** (decoded → wire) before the call and **decode results** (wire → runtime) after, using the registry's `args` / `returns` schemas. The mutation builders (`zm` / `zim`) likewise wrap `ctx.scheduler.runAfter` / `ctx.scheduler.runAt` to encode args. This means you can pass natural decoded values when calling into another wrapped function — including codecs whose runtime form can't cross the Convex boundary as-is (e.g. a Symbol-valued field) — and zodvex encodes them to wire at the call site, symmetric with the inbound decode the receiver already performs.
 
 ## Generated files
 

--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -175,6 +175,15 @@ function TaskDetail({ id }: { id: string }) {
 
 `encodeArgs` and `decodeResult` are lower-level helpers for non-hook use cases (e.g. form submit handlers, non-React clients).
 
+### `ZodvexClient` / `ZodvexReactClient` — codec-aware drop-in clients
+
+`createZodvexClient` (vanilla JS) and `createZodvexReactClient` (React) wrap Convex's `ConvexClient` / `ConvexReactClient` and apply registry codecs on every call — args are encoded to wire on the way out, results decoded to runtime on the way in. They aim to be **near drop-in replacements** for the Convex clients, exposing the same surface:
+
+- **`ZodvexClient`** (↔ `ConvexClient`): `query`, `mutate` (alias `mutation`), `action`, `subscribe` (alias `onUpdate`), `onPaginatedUpdate_experimental`, `getAuth`, `setAuth` (accepts a token string *or* an `AuthTokenFetcher` + `onChange`), `connectionState`, `subscribeToConnectionState`, `closed` / `disabled`, `close`. The inner client is reachable via the `convex` getter.
+- **`ZodvexReactClient`** (↔ `ConvexReactClient`): `query`, `mutation`, `action`, `watchQuery`, `prewarmQuery`, `setAuth`, `clearAuth`, `connectionState`, `subscribeToConnectionState`, `url`, `logger`, `close`.
+
+The data methods (`query` / `mutate` / `action` / `subscribe` / `watchQuery` / paginated) are codec-wrapped; the auth, connection, and lifecycle methods are thin pass-throughs to the underlying Convex client.
+
 ## Bootstrapping note
 
 The first time you run `zodvex generate`, your `functions.ts` likely already imports from `_zodvex/api.js` (to wire the registry). The CLI handles this chicken-and-egg problem by writing a minimal stub `api.js` before discovery runs, then overwriting it with the real generated output.

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "lint:fix": "bun run --cwd packages/zodvex lint:fix",
     "format": "bun run --cwd packages/zodvex format",
     "guard:source-boundaries": "bun scripts/check-source-boundaries.ts",
-    "verify:consumer-declarations": "bunx tsc -p test-fixtures/public-declaration-smoke/tsconfig.json",
+    "verify:consumer-declarations": "bun run --cwd packages/zodvex tsc -p ../../test-fixtures/public-declaration-smoke/tsconfig.json",
     "verify:examples": "bun run guard:mini-imports && bun run --cwd examples/stress-test typecheck && bun run --cwd examples/stress-test stress-test -- --count=11 && bun run --cwd examples/task-manager typecheck && bun run --cwd examples/task-manager test && bun run --cwd examples/task-manager generate && bun run --cwd examples/task-manager-mini typecheck && bun run --cwd examples/task-manager-mini test && bun run --cwd examples/task-manager-mini generate",
     "verify:examples:network": "bun run --cwd examples/task-manager dev:once && bun run --cwd examples/task-manager test:smoke && bun run --cwd examples/task-manager-mini dev:once && bun run --cwd examples/task-manager-mini test:smoke && bun run --cwd examples/quickstart dev:once && bun run --cwd examples/quickstart typecheck",
     "validate": "bun run lint && bun run type-check && bun run test && bun run verify:consumer-declarations && bun run build && bun run verify:examples && bun run verify:examples:network && bun run --cwd examples/stress-test stress-test",
-    "type-check:examples": "bunx tsc --noEmit -p examples/task-manager/convex/tsconfig.json && bunx tsc --noEmit -p examples/task-manager-mini/convex/tsconfig.json",
+    "type-check:examples": "bun run --cwd packages/zodvex tsc --noEmit -p ../../examples/task-manager/convex/tsconfig.json && bun run --cwd packages/zodvex tsc --noEmit -p ../../examples/task-manager-mini/convex/tsconfig.json",
     "guard:mini-imports": "! rg -n \"zodvex/core\" examples/task-manager-mini/convex examples/task-manager-mini/src"
   },
   "devDependencies": {}

--- a/packages/zodvex/__tests__/action-ctx.test.ts
+++ b/packages/zodvex/__tests__/action-ctx.test.ts
@@ -315,9 +315,10 @@ describe('createZodvexActionCtx', () => {
   // ---- Preserves other ctx properties ------------------------------------
 
   describe('ctx preservation', () => {
-    it('preserves other ctx properties (runAction, auth, scheduler, storage)', () => {
+    it('preserves other ctx properties (runAction, auth, storage) and wraps scheduler', () => {
       const authObj = { getUserIdentity: async () => ({ subject: 'user123' }) }
-      const schedulerObj = { runAfter: noop }
+      const cancelFn = async () => undefined
+      const schedulerObj = { runAfter: noop, runAt: noop, cancel: cancelFn }
       const storageObj = { getUrl: async () => 'https://example.com/file' }
       const runActionFn = async () => 'action result'
 
@@ -334,10 +335,13 @@ describe('createZodvexActionCtx', () => {
 
       // runAction should be the original (not wrapped)
       expect(wrappedCtx.runAction).toBe(runActionFn)
-      // auth, scheduler, storage should be preserved
+      // auth, storage should be preserved
       expect((wrappedCtx as any).auth).toBe(authObj)
-      expect((wrappedCtx as any).scheduler).toBe(schedulerObj)
       expect((wrappedCtx as any).storage).toBe(storageObj)
+      // scheduler is wrapped (auto-encodes codec args), but unwrapped members
+      // (e.g. cancel) pass through unchanged
+      expect((wrappedCtx as any).scheduler).not.toBe(schedulerObj)
+      expect((wrappedCtx as any).scheduler.cancel).toBe(cancelFn)
     })
 
     it('runQuery and runMutation are replaced (not the originals)', () => {
@@ -355,6 +359,164 @@ describe('createZodvexActionCtx', () => {
 
       expect(wrappedCtx.runQuery).not.toBe(originalRunQuery)
       expect(wrappedCtx.runMutation).not.toBe(originalRunMutation)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cross-function call path: auto-encode codec args (issue #76)
+//
+// Covers calling INTO another wrapped function via runMutation / scheduler with
+// *decoded* args, including:
+//  - a Symbol-valued codec whose runtime form (a JS Symbol) cannot cross the
+//    Convex boundary at all and must be encoded to a wire string.
+//  - a SensitiveField-style codec (runtime class instance <-> wire object).
+// ---------------------------------------------------------------------------
+
+// Symbol-valued codec: runtime NO_CONSTRAINT Symbol <-> wire '*'
+const NO_CONSTRAINT = Symbol('NO_CONSTRAINT')
+const scopeCodec = z.codec(
+  z.string(),
+  z.custom<symbol | string>(() => true),
+  {
+    decode: (wire: string) => (wire === '*' ? NO_CONSTRAINT : wire),
+    encode: (runtime: symbol | string) => (runtime === NO_CONSTRAINT ? '*' : (runtime as string))
+  }
+)
+
+// SensitiveField-style codec: runtime class instance <-> wire { value: string }
+class SensitiveField {
+  constructor(readonly value: string) {}
+}
+const sensitiveCodec = z.codec(
+  z.object({ value: z.string() }),
+  z.custom<SensitiveField>(() => true),
+  {
+    decode: (wire: { value: string }) => new SensitiveField(wire.value),
+    encode: (runtime: SensitiveField) => ({ value: runtime.value })
+  }
+)
+
+const crossCallRegistry = {
+  'presence:timeoutDisconnect': {
+    args: z.object({
+      presenceSessionId: z.string(),
+      _actor: z.object({ scope: scopeCodec })
+    })
+  },
+  'visits:activate': {
+    args: z.object({
+      visitId: z.string(),
+      name: sensitiveCodec
+    })
+  }
+} as const
+
+describe('createZodvexActionCtx — cross-function codec args (#76)', () => {
+  describe('runMutation', () => {
+    it('encodes a SensitiveField codec arg (class instance -> wire object)', async () => {
+      let captured: any = null
+      const mockCtx = {
+        runQuery: noop,
+        runMutation: async (_ref: any, args: any) => {
+          captured = args
+          return undefined
+        },
+        runAction: noop,
+        auth: { getUserIdentity: async () => null }
+      }
+
+      const wrappedCtx = createZodvexActionCtx(crossCallRegistry as any, mockCtx as any)
+      await wrappedCtx.runMutation(fakeRef('visits:activate'), {
+        visitId: 'v1',
+        name: new SensitiveField('top-secret')
+      })
+
+      expect(captured).toEqual({ visitId: 'v1', name: { value: 'top-secret' } })
+    })
+  })
+
+  describe('scheduler.runAfter', () => {
+    it('encodes a Symbol-valued codec arg (Symbol -> wire string)', async () => {
+      let captured: any[] = []
+      const mockCtx = {
+        runQuery: noop,
+        runMutation: noop,
+        runAction: noop,
+        scheduler: {
+          runAfter: async (...a: any[]) => {
+            captured = a
+            return 'job-1' as any
+          },
+          runAt: noop,
+          cancel: noop
+        },
+        auth: { getUserIdentity: async () => null }
+      }
+
+      const wrappedCtx = createZodvexActionCtx(crossCallRegistry as any, mockCtx as any)
+      await (wrappedCtx.scheduler as any).runAfter(5000, fakeRef('presence:timeoutDisconnect'), {
+        presenceSessionId: 'sess-1',
+        _actor: { scope: NO_CONSTRAINT }
+      })
+
+      expect(captured[0]).toBe(5000)
+      expect(captured[2]).toEqual({ presenceSessionId: 'sess-1', _actor: { scope: '*' } })
+    })
+
+    it('passes through scheduling a function with no args', async () => {
+      let captured: any[] = []
+      const mockCtx = {
+        runQuery: noop,
+        runMutation: noop,
+        runAction: noop,
+        scheduler: {
+          runAfter: async (...a: any[]) => {
+            captured = a
+            return 'job-2' as any
+          },
+          runAt: noop,
+          cancel: noop
+        },
+        auth: { getUserIdentity: async () => null }
+      }
+
+      const wrappedCtx = createZodvexActionCtx(crossCallRegistry as any, mockCtx as any)
+      await (wrappedCtx.scheduler as any).runAfter(0, fakeRef('unknown:noArgs'))
+
+      // No args supplied -> only (delayMs, ref) forwarded, no trailing undefined
+      expect(captured).toHaveLength(2)
+      expect(captured[0]).toBe(0)
+    })
+  })
+
+  describe('scheduler.runAt', () => {
+    it('encodes a SensitiveField codec arg (class instance -> wire object)', async () => {
+      let captured: any[] = []
+      const mockCtx = {
+        runQuery: noop,
+        runMutation: noop,
+        runAction: noop,
+        scheduler: {
+          runAfter: noop,
+          runAt: async (...a: any[]) => {
+            captured = a
+            return 'job-3' as any
+          },
+          cancel: noop
+        },
+        auth: { getUserIdentity: async () => null }
+      }
+
+      const when = new Date('2030-01-01T00:00:00Z')
+      const wrappedCtx = createZodvexActionCtx(crossCallRegistry as any, mockCtx as any)
+      await (wrappedCtx.scheduler as any).runAt(when, fakeRef('visits:activate'), {
+        visitId: 'v2',
+        name: new SensitiveField('hush')
+      })
+
+      expect(captured[0]).toBe(when)
+      expect(captured[2]).toEqual({ visitId: 'v2', name: { value: 'hush' } })
     })
   })
 })

--- a/packages/zodvex/__tests__/action-ctx.test.ts
+++ b/packages/zodvex/__tests__/action-ctx.test.ts
@@ -367,54 +367,61 @@ describe('createZodvexActionCtx', () => {
 // Cross-function call path: auto-encode codec args (issue #76)
 //
 // Covers calling INTO another wrapped function via runMutation / scheduler with
-// *decoded* args, including:
-//  - a Symbol-valued codec whose runtime form (a JS Symbol) cannot cross the
-//    Convex boundary at all and must be encoded to a wire string.
-//  - a SensitiveField-style codec (runtime class instance <-> wire object).
+// *decoded* args. Two codec shapes are exercised because they fail differently
+// without auto-encoding:
+//  - a sentinel codec whose runtime form is a JS Symbol — non-serializable, so
+//    it cannot cross the Convex boundary at all and MUST be encoded to a wire
+//    primitive.
+//  - a boxed-value codec whose runtime form is a class instance (serializable
+//    but the wrong shape) <-> a plain wire object.
+// Both are generic library concepts; consumers map their own domain codecs
+// (Symbol-valued enums, branded ids, encrypted fields, ...) onto the same two
+// shapes.
 // ---------------------------------------------------------------------------
 
-// Symbol-valued codec: runtime NO_CONSTRAINT Symbol <-> wire '*'
-const NO_CONSTRAINT = Symbol('NO_CONSTRAINT')
-const scopeCodec = z.codec(
+// Sentinel codec: runtime Symbol <-> wire string. A Symbol can't be serialized,
+// so without encoding the scheduled/run call would throw at the boundary.
+const WILDCARD = Symbol('WILDCARD')
+const sentinelCodec = z.codec(
   z.string(),
   z.custom<symbol | string>(() => true),
   {
-    decode: (wire: string) => (wire === '*' ? NO_CONSTRAINT : wire),
-    encode: (runtime: symbol | string) => (runtime === NO_CONSTRAINT ? '*' : (runtime as string))
+    decode: (wire: string) => (wire === '*' ? WILDCARD : wire),
+    encode: (runtime: symbol | string) => (runtime === WILDCARD ? '*' : (runtime as string))
   }
 )
 
-// SensitiveField-style codec: runtime class instance <-> wire { value: string }
-class SensitiveField {
+// Boxed-value codec: runtime class instance <-> wire { value: string }.
+class Boxed {
   constructor(readonly value: string) {}
 }
-const sensitiveCodec = z.codec(
+const boxedCodec = z.codec(
   z.object({ value: z.string() }),
-  z.custom<SensitiveField>(() => true),
+  z.custom<Boxed>(() => true),
   {
-    decode: (wire: { value: string }) => new SensitiveField(wire.value),
-    encode: (runtime: SensitiveField) => ({ value: runtime.value })
+    decode: (wire: { value: string }) => new Boxed(wire.value),
+    encode: (runtime: Boxed) => ({ value: runtime.value })
   }
 )
 
 const crossCallRegistry = {
-  'presence:timeoutDisconnect': {
+  'fns:withSentinel': {
     args: z.object({
-      presenceSessionId: z.string(),
-      _actor: z.object({ scope: scopeCodec })
+      id: z.string(),
+      flag: z.object({ scope: sentinelCodec })
     })
   },
-  'visits:activate': {
+  'fns:withBoxed': {
     args: z.object({
-      visitId: z.string(),
-      name: sensitiveCodec
+      id: z.string(),
+      secret: boxedCodec
     })
   }
 } as const
 
 describe('createZodvexActionCtx — cross-function codec args (#76)', () => {
   describe('runMutation', () => {
-    it('encodes a SensitiveField codec arg (class instance -> wire object)', async () => {
+    it('encodes a boxed-value codec arg (class instance -> wire object)', async () => {
       let captured: any = null
       const mockCtx = {
         runQuery: noop,
@@ -427,12 +434,12 @@ describe('createZodvexActionCtx — cross-function codec args (#76)', () => {
       }
 
       const wrappedCtx = createZodvexActionCtx(crossCallRegistry as any, mockCtx as any)
-      await wrappedCtx.runMutation(fakeRef('visits:activate'), {
-        visitId: 'v1',
-        name: new SensitiveField('top-secret')
+      await wrappedCtx.runMutation(fakeRef('fns:withBoxed'), {
+        id: 'a1',
+        secret: new Boxed('top-secret')
       })
 
-      expect(captured).toEqual({ visitId: 'v1', name: { value: 'top-secret' } })
+      expect(captured).toEqual({ id: 'a1', secret: { value: 'top-secret' } })
     })
   })
 
@@ -455,13 +462,13 @@ describe('createZodvexActionCtx — cross-function codec args (#76)', () => {
       }
 
       const wrappedCtx = createZodvexActionCtx(crossCallRegistry as any, mockCtx as any)
-      await (wrappedCtx.scheduler as any).runAfter(5000, fakeRef('presence:timeoutDisconnect'), {
-        presenceSessionId: 'sess-1',
-        _actor: { scope: NO_CONSTRAINT }
+      await (wrappedCtx.scheduler as any).runAfter(5000, fakeRef('fns:withSentinel'), {
+        id: 's1',
+        flag: { scope: WILDCARD }
       })
 
       expect(captured[0]).toBe(5000)
-      expect(captured[2]).toEqual({ presenceSessionId: 'sess-1', _actor: { scope: '*' } })
+      expect(captured[2]).toEqual({ id: 's1', flag: { scope: '*' } })
     })
 
     it('passes through scheduling a function with no args', async () => {
@@ -491,7 +498,7 @@ describe('createZodvexActionCtx — cross-function codec args (#76)', () => {
   })
 
   describe('scheduler.runAt', () => {
-    it('encodes a SensitiveField codec arg (class instance -> wire object)', async () => {
+    it('encodes a boxed-value codec arg (class instance -> wire object)', async () => {
       let captured: any[] = []
       const mockCtx = {
         runQuery: noop,
@@ -510,13 +517,13 @@ describe('createZodvexActionCtx — cross-function codec args (#76)', () => {
 
       const when = new Date('2030-01-01T00:00:00Z')
       const wrappedCtx = createZodvexActionCtx(crossCallRegistry as any, mockCtx as any)
-      await (wrappedCtx.scheduler as any).runAt(when, fakeRef('visits:activate'), {
-        visitId: 'v2',
-        name: new SensitiveField('hush')
+      await (wrappedCtx.scheduler as any).runAt(when, fakeRef('fns:withBoxed'), {
+        id: 'a2',
+        secret: new Boxed('hush')
       })
 
       expect(captured[0]).toBe(when)
-      expect(captured[2]).toEqual({ visitId: 'v2', name: { value: 'hush' } })
+      expect(captured[2]).toEqual({ id: 'a2', secret: { value: 'hush' } })
     })
   })
 })

--- a/packages/zodvex/__tests__/init.test.ts
+++ b/packages/zodvex/__tests__/init.test.ts
@@ -627,6 +627,57 @@ describe('initZodvex with registry', () => {
     expect(captured[2]).toEqual({ taskId: 't2', dueAt: dueAt.getTime() })
   })
 
+  it('zm scheduler encodes a non-serializable Symbol codec arg (Symbol -> wire string)', async () => {
+    // A sentinel codec whose runtime form is a JS Symbol — it cannot be
+    // serialized across the scheduler boundary, so it MUST be encoded to a wire
+    // primitive. This is the mutation-path analogue of the action-ctx test.
+    const WILDCARD = Symbol('WILDCARD')
+    const sentinelCodec = z.codec(
+      z.string(),
+      z.custom<symbol | string>(() => true),
+      {
+        decode: (wire: string) => (wire === '*' ? WILDCARD : wire),
+        encode: (runtime: symbol | string) => (runtime === WILDCARD ? '*' : (runtime as string))
+      }
+    )
+    const sentinelRegistry = {
+      'tasks:scoped': { args: z.object({ taskId: z.string(), scope: sentinelCodec }) }
+    }
+
+    const { zm } = initZodvex(mockSchema, mockServer as any, {
+      registry: () => sentinelRegistry
+    })
+
+    let captured: any[] = []
+
+    const fn = zm({
+      handler: async (ctx: any) => {
+        await ctx.scheduler.runAfter(0, fakeRef('tasks:scoped'), {
+          taskId: 't3',
+          scope: WILDCARD
+        })
+      }
+    })
+
+    const rawCtx = {
+      db: createMockDbWriter(userTableData).db,
+      scheduler: {
+        runAfter: async (...a: any[]) => {
+          captured = a
+          return 'job-3'
+        },
+        runAt: async () => 'job',
+        cancel: async () => undefined
+      }
+    }
+
+    await fn.handler(rawCtx, {})
+
+    expect(captured[2]).toEqual({ taskId: 't3', scope: '*' })
+    // The encoded value is a plain serializable string, not the Symbol.
+    expect(typeof captured[2].scope).toBe('string')
+  })
+
   it('zm without registry does not wrap scheduler', async () => {
     const { zm } = initZodvex(mockSchema, mockServer as any)
 

--- a/packages/zodvex/__tests__/init.test.ts
+++ b/packages/zodvex/__tests__/init.test.ts
@@ -549,6 +549,116 @@ describe('initZodvex with registry', () => {
     // User customization works
     expect(result.user).toBe('AuthUser')
   })
+
+  // --- Mutation scheduler: auto-encode codec args (issue #76) ---
+
+  const schedulerRegistry = {
+    'tasks:reminder': { args: z.object({ taskId: z.string(), dueAt: zx.date() }) }
+  }
+
+  it('zm handler scheduler.runAfter encodes codec args (Date -> number)', async () => {
+    const { zm } = initZodvex(mockSchema, mockServer as any, {
+      registry: () => schedulerRegistry
+    })
+
+    let captured: any[] = []
+    const dueAt = new Date('2030-01-01T00:00:00Z')
+
+    const fn = zm({
+      handler: async (ctx: any) => {
+        await ctx.scheduler.runAfter(1000, fakeRef('tasks:reminder'), {
+          taskId: 't1',
+          dueAt
+        })
+      }
+    })
+
+    const rawCtx = {
+      db: createMockDbWriter(userTableData).db,
+      scheduler: {
+        runAfter: async (...a: any[]) => {
+          captured = a
+          return 'job-1'
+        },
+        runAt: async () => 'job',
+        cancel: async () => undefined
+      }
+    }
+
+    await fn.handler(rawCtx, {})
+
+    expect(captured[0]).toBe(1000)
+    expect(captured[2]).toEqual({ taskId: 't1', dueAt: dueAt.getTime() })
+  })
+
+  it('zim handler scheduler.runAt encodes codec args (Date -> number)', async () => {
+    const { zim } = initZodvex(mockSchema, mockServer as any, {
+      registry: () => schedulerRegistry
+    })
+
+    let captured: any[] = []
+    const dueAt = new Date('2030-06-01T00:00:00Z')
+    const when = new Date('2030-05-01T00:00:00Z')
+
+    const fn = zim({
+      handler: async (ctx: any) => {
+        await ctx.scheduler.runAt(when, fakeRef('tasks:reminder'), {
+          taskId: 't2',
+          dueAt
+        })
+      }
+    })
+
+    const rawCtx = {
+      db: createMockDbWriter(userTableData).db,
+      scheduler: {
+        runAfter: async () => 'job',
+        runAt: async (...a: any[]) => {
+          captured = a
+          return 'job-2'
+        },
+        cancel: async () => undefined
+      }
+    }
+
+    await fn.handler(rawCtx, {})
+
+    expect(captured[0]).toBe(when)
+    expect(captured[2]).toEqual({ taskId: 't2', dueAt: dueAt.getTime() })
+  })
+
+  it('zm without registry does not wrap scheduler', async () => {
+    const { zm } = initZodvex(mockSchema, mockServer as any)
+
+    let captured: any[] = []
+    const dueAt = new Date('2030-01-01T00:00:00Z')
+    const schedulerObj = {
+      runAfter: async (...a: any[]) => {
+        captured = a
+        return 'job'
+      },
+      runAt: async () => 'job',
+      cancel: async () => undefined
+    }
+
+    const fn = zm({
+      handler: async (ctx: any) => {
+        // Scheduler must be the original, untouched object.
+        expect(ctx.scheduler).toBe(schedulerObj)
+        await ctx.scheduler.runAfter(0, fakeRef('tasks:reminder'), { taskId: 't', dueAt })
+      }
+    })
+
+    const rawCtx = {
+      db: createMockDbWriter(userTableData).db,
+      scheduler: schedulerObj
+    }
+
+    await fn.handler(rawCtx, {})
+
+    // No registry -> no encoding -> Date passes through unchanged
+    expect(captured[2].dueAt).toBeInstanceOf(Date)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/zodvex/__tests__/zodvex-client.test.ts
+++ b/packages/zodvex/__tests__/zodvex-client.test.ts
@@ -13,6 +13,7 @@ const { mocks, MockConvexClient } = vi.hoisted(() => {
     instancesCreated: 0,
     queryImpl: undefined as ((ref: any, args: any) => any) | undefined,
     mutationImpl: undefined as ((ref: any, args: any) => any) | undefined,
+    actionImpl: undefined as ((ref: any, args: any) => any) | undefined,
     onUpdateImpl: undefined as ((ref: any, args: any, cb: any) => () => void) | undefined,
     // setAuth receives an AuthTokenFetcher (async function), not a raw string.
     // We capture the fetchers so tests can resolve them.
@@ -34,6 +35,11 @@ const { mocks, MockConvexClient } = vi.hoisted(() => {
 
     async mutation(ref: any, args: any) {
       if (state.mutationImpl) return state.mutationImpl(ref, args)
+      return args
+    }
+
+    async action(ref: any, args: any) {
+      if (state.actionImpl) return state.actionImpl(ref, args)
       return args
     }
 
@@ -119,6 +125,7 @@ describe('ZodvexClient', () => {
   beforeEach(() => {
     mocks.queryImpl = undefined
     mocks.mutationImpl = undefined
+    mocks.actionImpl = undefined
     mocks.onUpdateImpl = undefined
     mocks.setAuthFetchers = []
     mocks.closeCalled = false
@@ -252,6 +259,50 @@ describe('ZodvexClient', () => {
       expect(capturedArgs).toBeDefined()
       expect(capturedArgs.title).toBe('Hello')
       expect('description' in capturedArgs).toBe(false)
+    })
+  })
+
+  // ---- action -------------------------------------------------------------
+
+  describe('action', () => {
+    it('encodes args and decodes results', async () => {
+      const dueDate = new Date('2026-06-15T00:00:00Z')
+      const ts = 1700000000000
+      let capturedArgs: any = null
+
+      mocks.actionImpl = (_ref: any, args: any) => {
+        capturedArgs = args
+        return { _id: 'act1', title: 'Ran', createdAt: ts }
+      }
+
+      const result = await client.action(fakeRef('tasks:create'), {
+        title: 'Ran',
+        dueAt: dueDate
+      })
+
+      // Args should be encoded: Date -> timestamp number
+      expect(capturedArgs.title).toBe('Ran')
+      expect(typeof capturedArgs.dueAt).toBe('number')
+      expect(capturedArgs.dueAt).toBe(dueDate.getTime())
+
+      // Return should be decoded: number -> Date
+      expect(result.createdAt).toBeInstanceOf(Date)
+      expect(result.createdAt.getTime()).toBe(ts)
+    })
+
+    it('passes through when function has no schemas', async () => {
+      const raw = { result: 'unchanged' }
+      let capturedArgs: any = null
+
+      mocks.actionImpl = (_ref: any, args: any) => {
+        capturedArgs = args
+        return raw
+      }
+
+      const result = await client.action(fakeRef('plain:noCodec'), { raw: 'data' })
+
+      expect(capturedArgs).toEqual({ raw: 'data' })
+      expect(result).toEqual(raw)
     })
   })
 

--- a/packages/zodvex/__tests__/zodvex-client.test.ts
+++ b/packages/zodvex/__tests__/zodvex-client.test.ts
@@ -15,9 +15,13 @@ const { mocks, MockConvexClient } = vi.hoisted(() => {
     mutationImpl: undefined as ((ref: any, args: any) => any) | undefined,
     actionImpl: undefined as ((ref: any, args: any) => any) | undefined,
     onUpdateImpl: undefined as ((ref: any, args: any, cb: any) => () => void) | undefined,
+    paginatedImpl: undefined as
+      | ((ref: any, args: any, options: any, cb: any) => () => void)
+      | undefined,
     // setAuth receives an AuthTokenFetcher (async function), not a raw string.
     // We capture the fetchers so tests can resolve them.
     setAuthFetchers: [] as any[],
+    setAuthOnChanges: [] as any[],
     closeCalled: false
   }
 
@@ -50,8 +54,21 @@ const { mocks, MockConvexClient } = vi.hoisted(() => {
       }
     }
 
-    setAuth(fetchToken: any) {
+    onPaginatedUpdate_experimental(
+      ref: any,
+      args: any,
+      options: any,
+      callback: (result: any) => void
+    ): () => void {
+      if (state.paginatedImpl) return state.paginatedImpl(ref, args, options, callback)
+      return () => {
+        /* no-op unsubscribe */
+      }
+    }
+
+    setAuth(fetchToken: any, onChange?: any) {
       state.setAuthFetchers.push(fetchToken)
+      state.setAuthOnChanges.push(onChange)
     }
 
     getAuth() {
@@ -149,7 +166,9 @@ describe('ZodvexClient', () => {
     mocks.mutationImpl = undefined
     mocks.actionImpl = undefined
     mocks.onUpdateImpl = undefined
+    mocks.paginatedImpl = undefined
     mocks.setAuthFetchers = []
+    mocks.setAuthOnChanges = []
     mocks.closeCalled = false
     mocks.instancesCreated = 0
     client = createZodvexClient(registry as any, { url: 'https://test.convex.cloud' })
@@ -328,6 +347,92 @@ describe('ZodvexClient', () => {
     })
   })
 
+  // ---- Convex-name aliases (mutation / onUpdate) --------------------------
+
+  describe('name aliases', () => {
+    it('mutation() is an alias for mutate() (encodes args, decodes result)', async () => {
+      const dueDate = new Date('2026-06-15T00:00:00Z')
+      const ts = 1700000000000
+      let capturedArgs: any = null
+
+      mocks.mutationImpl = (_ref: any, args: any) => {
+        capturedArgs = args
+        return { _id: 'm1', title: 'Via alias', createdAt: ts }
+      }
+
+      const result = await client.mutation(fakeRef('tasks:create'), {
+        title: 'Via alias',
+        dueAt: dueDate
+      })
+
+      expect(typeof capturedArgs.dueAt).toBe('number')
+      expect(capturedArgs.dueAt).toBe(dueDate.getTime())
+      expect(result.createdAt).toBeInstanceOf(Date)
+      expect(result.createdAt.getTime()).toBe(ts)
+    })
+
+    it('onUpdate() is an alias for subscribe() (encodes args, decodes result)', () => {
+      const ts = 1700000000000
+      let decoded: any = null
+      let capturedArgs: any = null
+
+      mocks.onUpdateImpl = (_ref: any, args: any, callback: any) => {
+        capturedArgs = args
+        callback({ _id: 'u1', title: 'Sub', createdAt: ts })
+        return () => {
+          /* no-op */
+        }
+      }
+
+      const dueDate = new Date('2026-06-15T00:00:00Z')
+      client.onUpdate(fakeRef('tasks:create'), { title: 'x', dueAt: dueDate }, (r: any) => {
+        decoded = r
+      })
+
+      expect(typeof capturedArgs.dueAt).toBe('number')
+      expect(decoded.createdAt).toBeInstanceOf(Date)
+    })
+  })
+
+  // ---- onPaginatedUpdate_experimental -------------------------------------
+
+  describe('onPaginatedUpdate_experimental', () => {
+    it('encodes args and decodes each page item', () => {
+      const ts = 1700000000000
+      const dueDate = new Date('2026-06-15T00:00:00Z')
+      let capturedArgs: any = null
+      let decoded: any = null
+
+      mocks.paginatedImpl = (_ref: any, args: any, _options: any, callback: any) => {
+        capturedArgs = args
+        callback({
+          page: [{ _id: 'p1', title: 'Paged', createdAt: ts }],
+          isDone: true,
+          continueCursor: ''
+        })
+        return () => {
+          /* no-op */
+        }
+      }
+
+      client.onPaginatedUpdate_experimental(
+        fakeRef('tasks:create'),
+        { title: 'x', dueAt: dueDate },
+        { initialNumItems: 10 },
+        (r: any) => {
+          decoded = r
+        }
+      )
+
+      // Args encoded: Date -> number
+      expect(typeof capturedArgs.dueAt).toBe('number')
+      // Each page item decoded: number -> Date
+      expect(decoded.page[0].createdAt).toBeInstanceOf(Date)
+      expect(decoded.page[0].createdAt.getTime()).toBe(ts)
+      expect(decoded.isDone).toBe(true)
+    })
+  })
+
   // ---- subscribe ----------------------------------------------------------
 
   describe('subscribe', () => {
@@ -436,6 +541,25 @@ describe('ZodvexClient', () => {
       expect(typeof mocks.setAuthFetchers[0]).toBe('function')
       const token = await lastTokenValue()
       expect(token).toBe(null)
+    })
+
+    it('accepts an AuthTokenFetcher + onChange (ConvexClient parity overload)', async () => {
+      const fetcher = async () => 'fetched-token'
+      const onChange = () => {
+        /* no-op */
+      }
+      client.setAuth(fetcher, onChange)
+
+      // Lazy until the inner client is created.
+      expect(mocks.setAuthFetchers).toHaveLength(0)
+      void client.convex
+
+      expect(mocks.setAuthFetchers).toHaveLength(1)
+      // The fetcher is forwarded as-is (not re-wrapped).
+      expect(mocks.setAuthFetchers[0]).toBe(fetcher)
+      expect(mocks.setAuthOnChanges[0]).toBe(onChange)
+      const token = await lastTokenValue()
+      expect(token).toBe('fetched-token')
     })
 
     it('delegates close to inner ConvexClient', async () => {

--- a/packages/zodvex/__tests__/zodvex-client.test.ts
+++ b/packages/zodvex/__tests__/zodvex-client.test.ts
@@ -54,6 +54,28 @@ const { mocks, MockConvexClient } = vi.hoisted(() => {
       state.setAuthFetchers.push(fetchToken)
     }
 
+    getAuth() {
+      return undefined
+    }
+
+    get closed() {
+      return false
+    }
+
+    get disabled() {
+      return false
+    }
+
+    connectionState() {
+      return { isWebSocketConnected: true } as any
+    }
+
+    subscribeToConnectionState(_cb: any) {
+      return () => {
+        /* no-op */
+      }
+    }
+
     async close() {
       state.closeCalled = true
     }
@@ -419,6 +441,35 @@ describe('ZodvexClient', () => {
     it('delegates close to inner ConvexClient', async () => {
       await client.close()
       expect(mocks.closeCalled).toBe(true)
+    })
+  })
+
+  // ---- connection & lifecycle parity --------------------------------------
+
+  describe('connection & lifecycle pass-throughs', () => {
+    it('exposes connectionState() from the inner client', () => {
+      const state = client.connectionState()
+      expect(state).toEqual({ isWebSocketConnected: true })
+    })
+
+    it('subscribeToConnectionState returns an unsubscribe function', () => {
+      const unsub = client.subscribeToConnectionState(() => {
+        /* no-op */
+      })
+      expect(typeof unsub).toBe('function')
+    })
+
+    it('getAuth() delegates to the inner client', () => {
+      expect(client.getAuth()).toBeUndefined()
+    })
+
+    it('closed/disabled are false before the inner client is created', () => {
+      // Fresh client — inner ConvexClient not yet instantiated.
+      const fresh = createZodvexClient(registry as any, { url: 'https://test.convex.cloud' })
+      expect(fresh.closed).toBe(false)
+      expect(fresh.disabled).toBe(false)
+      // Accessing the getters must NOT have forced the inner client into existence.
+      expect(mocks.instancesCreated).toBe(0)
     })
   })
 

--- a/packages/zodvex/__tests__/zodvex-react-client.test.ts
+++ b/packages/zodvex/__tests__/zodvex-react-client.test.ts
@@ -17,6 +17,7 @@ const { mocks, MockConvexReactClient } = vi.hoisted(() => {
     watchQueryImpl: undefined as
       | ((ref: any, args: any, opts: any) => { onUpdate: any; localQueryResult: any; journal: any })
       | undefined,
+    prewarmQueryImpl: undefined as ((queryOptions: any) => void) | undefined,
     setAuthCalls: [] as { fetchToken: any; onChange: any }[],
     clearAuthCalled: false,
     closeCalled: false,
@@ -59,6 +60,14 @@ const { mocks, MockConvexReactClient } = vi.hoisted(() => {
         localQueryResult: () => undefined,
         journal: () => undefined
       }
+    }
+
+    prewarmQuery(queryOptions: any) {
+      if (state.prewarmQueryImpl) state.prewarmQueryImpl(queryOptions)
+    }
+
+    get logger() {
+      return { logVerbose: () => undefined }
     }
 
     setAuth(fetchToken: any, onChange?: any) {
@@ -153,6 +162,7 @@ describe('ZodvexReactClient', () => {
     mocks.mutationImpl = undefined
     mocks.actionImpl = undefined
     mocks.watchQueryImpl = undefined
+    mocks.prewarmQueryImpl = undefined
     mocks.setAuthCalls = []
     mocks.clearAuthCalled = false
     mocks.closeCalled = false
@@ -323,6 +333,30 @@ describe('ZodvexReactClient', () => {
 
       expect(capturedArgs).toEqual({ raw: 'data' })
       expect(result).toEqual(raw)
+    })
+  })
+
+  // ---- prewarmQuery -------------------------------------------------------
+
+  describe('prewarmQuery', () => {
+    it('encodes args before delegating', () => {
+      const dueDate = new Date('2026-06-15T00:00:00Z')
+      let captured: any = null
+      mocks.prewarmQueryImpl = (queryOptions: any) => {
+        captured = queryOptions
+      }
+
+      client.prewarmQuery({
+        query: fakeRef('tasks:create'),
+        args: { title: 'Warm', dueAt: dueDate },
+        extendSubscriptionFor: 5000
+      })
+
+      expect(captured).toBeDefined()
+      expect(typeof captured.args.dueAt).toBe('number')
+      expect(captured.args.dueAt).toBe(dueDate.getTime())
+      // Non-arg fields pass through untouched.
+      expect(captured.extendSubscriptionFor).toBe(5000)
     })
   })
 

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.4",
+  "version": "0.7.5-beta.0",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",

--- a/packages/zodvex/src/internal/actionCtx.ts
+++ b/packages/zodvex/src/internal/actionCtx.ts
@@ -1,14 +1,83 @@
-import type { GenericActionCtx, GenericDataModel } from 'convex/server'
-import type { BoundaryHelpersOptions } from './boundaryHelpers'
+import type { GenericActionCtx, GenericDataModel, Scheduler } from 'convex/server'
+import type { BoundaryHelpers, BoundaryHelpersOptions } from './boundaryHelpers'
 import { createBoundaryHelpers } from './boundaryHelpers'
 import type { AnyRegistry } from './types'
 
 /**
- * Wraps an action context's runQuery/runMutation with automatic
+ * Wraps a `runQuery`/`runMutation` function so it encodes codec args
+ * (runtime -> wire) before the call and decodes the result (wire -> runtime)
+ * after. Functions not in the registry pass through unchanged.
+ */
+function wrapRun(fn: (ref: any, ...rest: any[]) => Promise<any>, codec: BoundaryHelpers) {
+  return async (ref: any, ...restArgs: any[]) => {
+    const wireArgs = codec.encodeArgs(ref, restArgs[0])
+    const wireResult = await fn(ref, wireArgs)
+    return codec.decodeResult(ref, wireResult)
+  }
+}
+
+/**
+ * Wraps a {@link Scheduler} so `runAfter`/`runAt` encode codec args to wire
+ * before scheduling.
+ *
+ * A scheduled function crosses the Convex boundary exactly like `runMutation`:
+ * the caller holds *decoded* (runtime) values, but Convex serializes the args
+ * against the target's *wire* validator. A non-serializable runtime value (e.g.
+ * a Symbol-valued codec field) cannot cross at all, and branded/`SensitiveField`
+ * codecs are the wrong shape — so the args must be encoded first.
+ *
+ * Return values are NOT decoded: the scheduler returns the scheduled-function
+ * id, not the target's result. Other members (e.g. `cancel`) pass through.
+ */
+function wrapScheduler(scheduler: Scheduler, codec: BoundaryHelpers): Scheduler {
+  const wrapped: any = { ...scheduler }
+  wrapped.runAfter = (delayMs: number, ref: any, ...restArgs: any[]) => {
+    const wireArgs = codec.encodeArgs(ref, restArgs[0])
+    return (scheduler.runAfter as any)(delayMs, ref, ...(restArgs.length ? [wireArgs] : []))
+  }
+  wrapped.runAt = (timestamp: number | Date, ref: any, ...restArgs: any[]) => {
+    const wireArgs = codec.encodeArgs(ref, restArgs[0])
+    return (scheduler.runAt as any)(timestamp, ref, ...(restArgs.length ? [wireArgs] : []))
+  }
+  return wrapped as Scheduler
+}
+
+/**
+ * Builds ctx overrides that auto-encode codec args at outbound call sites:
+ * - `runQuery` / `runMutation`: encode args, decode result.
+ * - `scheduler.runAfter` / `scheduler.runAt`: encode args.
+ *
+ * Only the members present on the given ctx are included, so this serves both
+ * action ctx (run* + scheduler) and mutation ctx (scheduler only).
+ *
+ * @internal Used by initZodvex when the `registry` option is provided.
+ */
+export function createCodecCallOverrides(
+  registry: AnyRegistry,
+  ctx: { runQuery?: unknown; runMutation?: unknown; scheduler?: Scheduler },
+  options?: BoundaryHelpersOptions
+): Record<string, unknown> {
+  const codec = createBoundaryHelpers(registry, options)
+  const overrides: Record<string, unknown> = {}
+  if (typeof ctx.runQuery === 'function') {
+    overrides.runQuery = wrapRun(ctx.runQuery as any, codec)
+  }
+  if (typeof ctx.runMutation === 'function') {
+    overrides.runMutation = wrapRun(ctx.runMutation as any, codec)
+  }
+  if (ctx.scheduler) {
+    overrides.scheduler = wrapScheduler(ctx.scheduler, codec)
+  }
+  return overrides
+}
+
+/**
+ * Wraps an action context's runQuery/runMutation and scheduler with automatic
  * codec transforms via the zodvex registry.
  *
  * - Args are encoded (runtime -> wire) before calling the inner function
  * - Results are decoded (wire -> runtime) before returning to the handler
+ *   (runQuery/runMutation only — the scheduler returns a scheduled-function id)
  * - Functions not in the registry pass through unchanged
  *
  * @internal Used by initZodvex when registry option is provided.
@@ -18,19 +87,5 @@ export function createZodvexActionCtx<DM extends GenericDataModel>(
   ctx: GenericActionCtx<DM>,
   options?: BoundaryHelpersOptions
 ): GenericActionCtx<DM> {
-  const codec = createBoundaryHelpers(registry, options)
-
-  return {
-    ...ctx,
-    runQuery: async (ref: any, ...restArgs: any[]) => {
-      const wireArgs = codec.encodeArgs(ref, restArgs[0])
-      const wireResult = await ctx.runQuery(ref, wireArgs)
-      return codec.decodeResult(ref, wireResult)
-    },
-    runMutation: async (ref: any, ...restArgs: any[]) => {
-      const wireArgs = codec.encodeArgs(ref, restArgs[0])
-      const wireResult = await ctx.runMutation(ref, wireArgs)
-      return codec.decodeResult(ref, wireResult)
-    }
-  } as GenericActionCtx<DM>
+  return { ...ctx, ...createCodecCallOverrides(registry, ctx, options) } as GenericActionCtx<DM>
 }

--- a/packages/zodvex/src/internal/init.ts
+++ b/packages/zodvex/src/internal/init.ts
@@ -10,7 +10,7 @@ import type {
 } from 'convex/server'
 import { NoOp } from 'convex-helpers/server/customFunctions'
 import type { z } from 'zod'
-import { createZodvexActionCtx } from './actionCtx'
+import { createCodecCallOverrides } from './actionCtx'
 import type { CustomBuilder } from './custom'
 import { zCustomAction, zCustomMutation, zCustomQuery } from './custom'
 import { createZodvexCustomization } from './customization'
@@ -285,10 +285,11 @@ export function initZodvex(
   const noOp = createNoOpCustomization()
   const wrap = options?.wrapDb !== false
 
-  const actionCust = createActionCustomization(options?.registry, noOp)
+  const registryThunk = options?.registry
+  const actionCust = createActionCustomization(registryThunk, noOp)
   const customizations = {
     query: wrap ? codec.query : noOp,
-    mutation: wrap ? codec.mutation : noOp,
+    mutation: createMutationCustomization(wrap ? codec.mutation : noOp, registryThunk),
     action: actionCust
   }
 
@@ -309,10 +310,38 @@ function createActionCustomization(
 
   return {
     args: {} as Record<string, never>,
-    input: async (ctx: any) => {
-      const wrapped = createZodvexActionCtx(registryThunk(), ctx)
+    input: async (ctx: any) => ({
+      // Auto-encode codec args at outbound call sites: runQuery/runMutation
+      // (encode args, decode result) and scheduler.runAfter/runAt (encode args).
+      ctx: createCodecCallOverrides(registryThunk(), ctx),
+      args: {}
+    })
+  }
+}
+
+/**
+ * Composes the codec DB customization with outbound codec-arg encoding for the
+ * mutation builders. Mutations expose `ctx.scheduler` (runAfter/runAt), so when
+ * a registry is provided those calls auto-encode decoded codec args to wire —
+ * symmetric with the inbound decode the receiving function already performs.
+ *
+ * Without a registry, the DB customization is returned unchanged.
+ */
+function createMutationCustomization(
+  dbCust: InternalCustomization,
+  registryThunk: (() => AnyRegistry) | undefined
+): InternalCustomization {
+  if (!registryThunk) {
+    return dbCust
+  }
+
+  return {
+    args: {} as Record<string, never>,
+    input: async (ctx: any, _args: any, extra?: any) => {
+      const dbResult = await dbCust.input(ctx, {}, extra)
+      const callOverrides = createCodecCallOverrides(registryThunk(), ctx)
       return {
-        ctx: { runQuery: wrapped.runQuery, runMutation: wrapped.runMutation },
+        ctx: { ...dbResult.ctx, ...callOverrides },
         args: {}
       }
     }

--- a/packages/zodvex/src/public/client/zodvexClient.ts
+++ b/packages/zodvex/src/public/client/zodvexClient.ts
@@ -1,4 +1,4 @@
-import type { AuthTokenFetcher } from 'convex/browser'
+import type { AuthTokenFetcher, ConnectionState, MutationOptions } from 'convex/browser'
 import { ConvexClient } from 'convex/browser'
 import type { FunctionArgs, FunctionReference, FunctionReturnType } from 'convex/server'
 import type { BoundaryHelpersOptions } from '../../internal/boundaryHelpers'
@@ -65,11 +65,13 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
 
   async mutate<M extends FunctionReference<'mutation', any, any, any>>(
     ref: M,
-    args: M['_args']
+    args: M['_args'],
+    options?: MutationOptions
   ): Promise<M['_returnType']> {
     const wireResult = await this.getConvex().mutation(
       ref,
-      this.codec.encodeArgs(ref, args) as FunctionArgs<M>
+      this.codec.encodeArgs(ref, args) as FunctionArgs<M>,
+      options
     )
     return this.codec.decodeResult(ref, wireResult)
   }
@@ -88,12 +90,18 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
   subscribe<Q extends FunctionReference<'query', any, any, any>>(
     ref: Q,
     args: Q['_args'],
-    callback: (result: Q['_returnType']) => void
+    callback: (result: Q['_returnType']) => void,
+    onError?: (e: Error) => void
   ): () => void {
     const wireArgs = this.codec.encodeArgs(ref, args) as FunctionArgs<Q>
-    return this.getConvex().onUpdate(ref, wireArgs, (wireResult: FunctionReturnType<Q>) => {
-      callback(this.codec.decodeResult(ref, wireResult))
-    })
+    return this.getConvex().onUpdate(
+      ref,
+      wireArgs,
+      (wireResult: FunctionReturnType<Q>) => {
+        callback(this.codec.decodeResult(ref, wireResult))
+      },
+      onError
+    )
   }
 
   setAuth(token: string | null) {
@@ -102,6 +110,29 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
     if (this.innerClient) {
       this.innerClient.setAuth(fetcher)
     }
+  }
+
+  /** Returns the current auth token and its decoded claims, if authenticated. */
+  getAuth(): { token: string; decoded: Record<string, any> } | undefined {
+    return this.getConvex().getAuth()
+  }
+
+  /** Whether this client has been closed. False before the inner client is created. */
+  get closed(): boolean {
+    return this.innerClient?.closed ?? false
+  }
+
+  /** Whether this client is disabled. False before the inner client is created. */
+  get disabled(): boolean {
+    return this.innerClient?.disabled ?? false
+  }
+
+  connectionState(): ConnectionState {
+    return this.getConvex().connectionState()
+  }
+
+  subscribeToConnectionState(cb: (state: ConnectionState) => void): () => void {
+    return this.getConvex().subscribeToConnectionState(cb)
   }
 
   async close() {

--- a/packages/zodvex/src/public/client/zodvexClient.ts
+++ b/packages/zodvex/src/public/client/zodvexClient.ts
@@ -21,6 +21,7 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
   private innerClient?: ConvexClient
   private url?: string
   private pendingAuthFetcher?: AuthTokenFetcher
+  private pendingAuthOnChange?: (isAuthenticated: boolean) => void
 
   constructor(registry: R, options: ZodvexClientOptions) {
     this.codec = createBoundaryHelpers(registry, { onDecodeError: options.onDecodeError })
@@ -42,7 +43,7 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
 
     const client = new ConvexClient(this.getUrl())
     if (this.pendingAuthFetcher) {
-      client.setAuth(this.pendingAuthFetcher)
+      client.setAuth(this.pendingAuthFetcher, this.pendingAuthOnChange)
     }
     this.innerClient = client
     return client
@@ -76,6 +77,15 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
     return this.codec.decodeResult(ref, wireResult)
   }
 
+  /** Alias for {@link mutate} — matches `ConvexClient.mutation` / `ZodvexReactClient.mutation`. */
+  mutation<M extends FunctionReference<'mutation', any, any, any>>(
+    ref: M,
+    args: M['_args'],
+    options?: MutationOptions
+  ): Promise<M['_returnType']> {
+    return this.mutate(ref, args, options)
+  }
+
   async action<A extends FunctionReference<'action', any, any, any>>(
     ref: A,
     args: A['_args']
@@ -104,11 +114,64 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
     )
   }
 
-  setAuth(token: string | null) {
-    const fetcher = async () => token
+  /** Alias for {@link subscribe} — matches `ConvexClient.onUpdate`. */
+  onUpdate<Q extends FunctionReference<'query', any, any, any>>(
+    ref: Q,
+    args: Q['_args'],
+    callback: (result: Q['_returnType']) => void,
+    onError?: (e: Error) => void
+  ): () => void {
+    return this.subscribe(ref, args, callback, onError)
+  }
+
+  /**
+   * Experimental paginated subscription. Encodes args to wire and decodes each
+   * page item through the registry, mirroring {@link subscribe}.
+   */
+  onPaginatedUpdate_experimental<Q extends FunctionReference<'query', any, any, any>>(
+    ref: Q,
+    args: Q['_args'],
+    options: { initialNumItems: number },
+    callback: (result: {
+      page: Q['_returnType'][]
+      isDone: boolean
+      continueCursor: string
+      [key: string]: unknown
+    }) => void,
+    onError?: (e: Error) => void
+  ): ReturnType<ConvexClient['onPaginatedUpdate_experimental']> {
+    const wireArgs = this.codec.encodeArgs(ref, args) as FunctionArgs<Q>
+    return this.getConvex().onPaginatedUpdate_experimental(
+      ref,
+      wireArgs,
+      options,
+      (wireResult: any) => {
+        callback({
+          ...wireResult,
+          page: wireResult.page.map((item: any) => this.codec.decodeResult(ref, item))
+        })
+      },
+      onError
+    ) as ReturnType<ConvexClient['onPaginatedUpdate_experimental']>
+  }
+
+  /**
+   * Set the auth token. Accepts either a raw token string (convenience) or a
+   * Convex `AuthTokenFetcher` plus optional `onChange` callback (parity with
+   * `ConvexClient.setAuth`).
+   */
+  setAuth(token: string | null): void
+  setAuth(fetchToken: AuthTokenFetcher, onChange?: (isAuthenticated: boolean) => void): void
+  setAuth(
+    tokenOrFetcher: string | null | AuthTokenFetcher,
+    onChange?: (isAuthenticated: boolean) => void
+  ): void {
+    const fetcher: AuthTokenFetcher =
+      typeof tokenOrFetcher === 'function' ? tokenOrFetcher : async () => tokenOrFetcher
     this.pendingAuthFetcher = fetcher
+    this.pendingAuthOnChange = onChange
     if (this.innerClient) {
-      this.innerClient.setAuth(fetcher)
+      this.innerClient.setAuth(fetcher, onChange)
     }
   }
 

--- a/packages/zodvex/src/public/client/zodvexClient.ts
+++ b/packages/zodvex/src/public/client/zodvexClient.ts
@@ -74,6 +74,17 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
     return this.codec.decodeResult(ref, wireResult)
   }
 
+  async action<A extends FunctionReference<'action', any, any, any>>(
+    ref: A,
+    args: A['_args']
+  ): Promise<A['_returnType']> {
+    const wireResult = await this.getConvex().action(
+      ref,
+      this.codec.encodeArgs(ref, args) as FunctionArgs<A>
+    )
+    return this.codec.decodeResult(ref, wireResult)
+  }
+
   subscribe<Q extends FunctionReference<'query', any, any, any>>(
     ref: Q,
     args: Q['_args'],

--- a/packages/zodvex/src/public/react/zodvexReactClient.ts
+++ b/packages/zodvex/src/public/react/zodvexReactClient.ts
@@ -139,6 +139,10 @@ export class ZodvexReactClient<R extends AnyRegistry = AnyRegistry> {
     return this.getUrl()
   }
 
+  get logger(): ConvexReactClient['logger'] {
+    return this.getConvex().logger
+  }
+
   connectionState() {
     return this.getConvex().connectionState()
   }

--- a/packages/zodvex/src/public/react/zodvexReactClient.ts
+++ b/packages/zodvex/src/public/react/zodvexReactClient.ts
@@ -84,6 +84,19 @@ export class ZodvexReactClient<R extends AnyRegistry = AnyRegistry> {
     return this.codec.decodeResult(ref, wireResult)
   }
 
+  /**
+   * Indicates likely future interest in a query subscription. Encodes args to
+   * wire before delegating, mirroring {@link watchQuery}.
+   */
+  prewarmQuery<Q extends FunctionReference<'query', any, any, any>>(queryOptions: {
+    query: Q
+    args: Q['_args']
+    extendSubscriptionFor?: number
+  }): void {
+    const wireArgs = this.codec.encodeArgs(queryOptions.query, queryOptions.args) as FunctionArgs<Q>
+    this.getConvex().prewarmQuery({ ...queryOptions, args: wireArgs })
+  }
+
   watchQuery<Q extends FunctionReference<'query', any, any, any>>(
     ref: Q,
     args: Q['_args'],


### PR DESCRIPTION
Closes #76

This branch grew from the #76 scheduler fix into a broader codec-boundary parity effort. It covers three related pieces of work, plus tooling/docs and a version bump to `0.7.5-beta.0`.

## 1. Auto-encode codec args at cross-function call sites (#76)

zodvex auto-encodes/decodes codec fields at a wrapped function's **own** boundary, but did **not** do so when one function calls **into** another wrapped function. At those sites the caller holds *decoded* (runtime) values, but the value must cross the Convex boundary as *wire* JSON — so callers were forced to manually `encode` + cast.

- **Typing was already correct.** zodvex's `CustomBuilder` surfaces the **decoded** type (`z.output`) on the generated `FunctionReference` while the registered Convex validator is wire — so Convex already types these args as decoded; passing decoded values type-checks with no cast.
- **The runtime gap.** Action contexts already encoded `runQuery`/`runMutation` args, but the **scheduler was never wrapped anywhere**, and **mutation-context schedulers weren't wrapped at all**. A codec whose runtime form is a non-serializable JS `Symbol` literally can't cross the boundary unencoded.

Changes:
- `actionCtx.ts` — new `wrapScheduler` (encodes args on `runAfter`/`runAt`, passes through `cancel`, doesn't decode the scheduled-function id) and reusable `createCodecCallOverrides`.
- `init.ts` — mutation builders (`zm`/`zim`) now wrap `ctx.scheduler` when a `registry` is provided (`createMutationCustomization`), composed with the existing db-codec wrapping; the action customization includes the scheduler too.
- `runAction` is intentionally left unwrapped (matches existing behavior and the issue's scope).

## 2. `ZodvexClient.action()` for the plain JS client

The plain JS `ZodvexClient` exposed `query`/`mutate`/`subscribe` but not `action`, so non-React consumers couldn't call Convex actions through the codec boundary. Added `action()`, symmetric with `mutate()`. (The React client already had it.)

## 3. Full parity with `ConvexClient` / `ConvexReactClient`

Audit showed the plain client was missing several non-codec methods (an omission, not a deliberate minimal surface — even zodvex's own React client had diverged from the plain one). Closed the gaps:

- **`ZodvexClient`** (↔ `ConvexClient`): `getAuth`, `connectionState`, `subscribeToConnectionState`, `closed`/`disabled` getters, `setAuth` now also accepts an `AuthTokenFetcher` + `onChange` (overload, keeps the `string|null` convenience), `mutation()`/`onUpdate()` aliases, `onPaginatedUpdate_experimental`; `mutate()` takes `MutationOptions`; `subscribe()` forwards `onError`.
- **`ZodvexReactClient`** (↔ `ConvexReactClient`): `prewarmQuery`, `logger` getter.

Data methods (`query`/`mutate`/`action`/`subscribe`/`watchQuery`/paginated) are codec-wrapped; auth/connection/lifecycle methods are thin pass-throughs.

## Tooling / docs

- **Infra fix:** `verify:consumer-declarations` and `type-check:examples` ran via `bunx tsc`, which resolves a floating-latest TypeScript (6.0.2) rather than the pinned 5.9.3 — TS 6 reports the fixtures' `baseUrl` as a deprecation error and broke `validate`/`release-beta` on any machine without a global TS 5.x. Both now run through the workspace tsc.
- **Docs:** README + codegen guide updated for scheduler auto-encode and the near-drop-in client surface.

## Tests

Consumer-agnostic coverage (generic codec shapes, no consumer-domain vocabulary):
- a **sentinel codec** whose runtime form is a non-serializable JS `Symbol`, and a **boxed-value codec** whose runtime form is a class instance — across `runMutation`, `scheduler.runAfter`, `scheduler.runAt` (action ctx) and the `zm`/`zim` scheduler path (both `Date` and `Symbol` codecs), plus no-args / no-registry passthrough.
- New client tests: `action`, `mutation`/`onUpdate` aliases, `onPaginatedUpdate_experimental`, `setAuth` fetcher overload, connection/lifecycle pass-throughs (plain), and `prewarmQuery` (React).

## Verification

- Full `bun run validate` is **green end-to-end**, including the network step: lint, type-check, **2062 tests**, consumer-declarations, build, `verify:examples`, `verify:examples:network` (real Convex deploys of task-manager / task-manager-mini / quickstart + HTTP smoke tests), and the full stress-test ceiling search.
- Note: the examples' Convex dev deployments had been deleted upstream and were reprovisioned under the `panzacoder` team (`.env.local` only — no repo changes needed).
- **`zodvex@0.7.5-beta.0` is published** (`npm view zodvex@beta version` → `0.7.5-beta.0`); tag `v0.7.5-beta.0` points at this branch's HEAD (b85f827). Release workflow run: https://github.com/panzacoder/zodvex/actions/runs/27310237861

Version `0.7.5-beta.0` is out for downstream trial (hotpot).

https://claude.ai/code/session_012RMHNHzgSRjea8a4PgdBP4
