### PR TITLE
feat(server): zodvexStream/zodvexMergedStream — typed stream interop for the secure reader (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — targeting 0.7.6
+
+### Added
+
+- **`zodvexStream` / `zodvexMergedStream`** (`zodvex/server`) — typed `convex-helpers/server/stream` interop for the secure `ctx.db` (#78). Enables honest pagination over set-valued equality predicates (`roomId IN {a, b, c}`): fan out one substream per value, k-way merge with `zodvexMergedStream(substreams, orderByIndexFields).paginate(opts)`. No more double-casting the secure reader at call sites — the unavoidable cast lives in one audited place inside zodvex, pinned by tests that exercise the duck-typed surface `stream()` relies on. Streamed item/page types are the **decoded** doc types (codec outputs applied), matching what the zodvex chain actually yields. Streams are rules-preserving: each row flows through decode + read rules mid-stream; denied rows never enter the cursor space (no holes, no stuck cursors). Codec-backed fields are rejected in `orderByIndexFields` (the merge comparator would compare decoded values against a wire-ordered index). See `docs/guide/streams.md`.
+
 ## [0.7.4] - 2026-06-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — targeting 0.7.6
+## [0.7.6] - 2026-06-12
 
 ### Added
 
-- **`zodvexStream` / `zodvexMergedStream`** (`zodvex/server`) — typed `convex-helpers/server/stream` interop for the secure `ctx.db` (#78). Enables honest pagination over set-valued equality predicates (`roomId IN {a, b, c}`): fan out one substream per value, k-way merge with `zodvexMergedStream(substreams, orderByIndexFields).paginate(opts)`. No more double-casting the secure reader at call sites — the unavoidable cast lives in one audited place inside zodvex, pinned by tests that exercise the duck-typed surface `stream()` relies on. Streamed item/page types are the **decoded** doc types (codec outputs applied), matching what the zodvex chain actually yields. Streams are rules-preserving: each row flows through decode + read rules mid-stream; denied rows never enter the cursor space (no holes, no stuck cursors). Codec-backed fields are rejected in `orderByIndexFields` (the merge comparator would compare decoded values against a wire-ordered index). See `docs/guide/streams.md`.
+- **`zodvexStream` / `zodvexMergedStream`** (`zodvex/server`) — typed `convex-helpers/server/stream` interop for the secure `ctx.db` (#78). Enables honest pagination over set-valued equality predicates (`roomId IN {a, b, c}`): fan out one substream per value, k-way merge with `zodvexMergedStream(substreams, orderByIndexFields).paginate(opts)`. No more double-casting the secure reader at call sites — the unavoidable cast lives in one audited place inside zodvex, pinned by tests that exercise the duck-typed surface `stream()` relies on. Streamed item/page types are the **decoded** doc types (codec outputs applied), matching what the zodvex chain actually yields. Streams are rules-preserving: each row flows through decode + read rules mid-stream; denied rows never enter the cursor space (no holes, no stuck cursors). Codec-backed fields are rejected in `orderByIndexFields` (the merge comparator would compare decoded values against a wire-ordered index) — the throw is fail-fast at `zodvexMergedStream()` construction, before any database access, and protects substreams created via `zodvexStream` (raw convex-helpers streams pass through unchecked as the incremental-migration path). See `docs/guide/streams.md`. Verified downstream against hotpot (drop-in migration + live cursor smokes, then codec-bearing-table coverage of decoded typing and the merge-key rejection).
 
 ## [0.7.4] - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ npx zodvex migrate ./convex --dry-run  # preview changes
 - [Return Type Helpers](./docs/guide/return-type-helpers.md) — `returnsAs`
 - [Large Schemas](./docs/guide/large-schemas.md) — `pickShape`, `safePick`
 - [Polymorphic Tables](./docs/guide/polymorphic-tables.md) — Union/discriminated union tables
+- [Streams](./docs/guide/streams.md) — `zodvexStream`, `zodvexMergedStream` for fan-out pagination
 - [AI SDK Compatibility](./docs/guide/ai-sdk.md) — Vercel AI SDK integration
 - [Codegen](./docs/guide/codegen.md) — CLI, registry, typed hooks
 

--- a/docs/guide/streams.md
+++ b/docs/guide/streams.md
@@ -60,6 +60,10 @@ zodvexMergedStream(substreams, ['_creationTime'])
 
 The merge comparator reads index-key values off the *yielded* (decoded) documents, while the underlying Convex index is ordered by *wire* values — decoded comparisons can mis-order the merge, and decoded values (like `Date`) are not serializable into pagination cursors.
 
+The guard is **fail-fast**: stream construction is lazy, so the throw fires synchronously at `zodvexMergedStream()` call time, before anything touches the database — a query-build-time error, not a mid-pagination surprise after N pages.
+
+**Guard scope:** the codec merge-key guard only protects substreams created via `zodvexStream` — it works by reflecting the table's zodvex schema off each stream. Substreams built with raw convex-helpers `stream()` (e.g. legacy cast-based call sites mid-migration), or derived streams that don't reflect (`filterWith`, `map`), still merge fine but get no codec check. This is intentional — raw streams are the incremental-migration path — but mixed raw/zodvex stream arrays get no protection on the raw members.
+
 The same caution applies to paginating a single stream whose index range is *bounded* (not `.eq()`-pinned) on a codec field: cursors serialize index-key values from decoded docs. Prefer indexes whose ordering tail is non-codec (`_creationTime` is always safe).
 
 ## API

--- a/docs/guide/streams.md
+++ b/docs/guide/streams.md
@@ -1,0 +1,74 @@
+# Streams: `zodvexStream` and `zodvexMergedStream`
+
+Typed interop with [`convex-helpers/server/stream`](https://github.com/get-convex/convex-helpers#composable-querystreams) for the zodvex secure `ctx.db` — no casts at call sites, decoded document types end to end.
+
+## When you need streams
+
+Streams matter for one specific, increasingly common query shape: **honest pagination over a set-valued equality predicate**. `roomId IN {a, b, c}` is not a single Convex index range, so the only way to paginate it without post-fetch filtering (short/uneven pages, dead scans) is to fan out one substream per value over an index like `(tenantId, roomId, status)` and k-way merge them. Index-key cursors stay valid across all substreams.
+
+## Usage
+
+```ts
+import { zodvexMergedStream, zodvexStream } from 'zodvex/server'
+import schema from './schema'
+
+export const visitsForRooms = zq({
+  args: { rooms: z.array(z.string()), paginationOpts: zx.paginationOpts() },
+  handler: async (ctx, { rooms, paginationOpts }) => {
+    const substreams = rooms.map(roomId =>
+      zodvexStream(ctx.db, schema)
+        .query('visits')
+        .withIndex('tenantId_roomId', q => q.eq('tenantId', tenantId).eq('roomId', roomId))
+        .order('asc')
+    )
+    return zodvexMergedStream(substreams, ['_creationTime']).paginate(paginationOpts)
+  }
+})
+```
+
+`zodvexStream(db, schema)` takes the secure reader (`ctx.db` from `initZodvex` builders — readers and writers both work) and the `defineZodSchema()` result. The returned stream has the same fluent surface as convex-helpers' `stream()`.
+
+## What you get over a raw cast
+
+Without this entry point, the working pattern was a double-cast (`ctx.db as unknown as GenericDatabaseReader<DataModel>`), which lies twice:
+
+1. The cast asserts, per call site and unaudited, that the secure reader is a raw reader.
+2. convex-helpers types streamed docs as raw wire documents, but the zodvex reader actually yields **decoded** docs (codec outputs applied — `Date` instead of `number`, etc.).
+
+`zodvexStream` fixes both:
+
+- The unavoidable cast lives in **one audited place** inside zodvex, pinned by tests that exercise the duck-typed surface `stream()` relies on (`db.query(table).withIndex(...).order(...)` plus async iteration). If a future zodvex version changes the chain surface, zodvex CI fails loudly — not your app, silently.
+- Item and page types are the **decoded** doc types, so `mergedStream(...).paginate()` returns pages that match what zodvex actually yields.
+
+## Rules semantics
+
+Streams are **rules-preserving**: every streamed row flows through the secure chain, so codec decode and any `.withRules()` / `.audit()` wrappers on the reader apply per row, mid-stream.
+
+If a read rule denies a row inside a substream, the row is simply never yielded — the merged index-key cursor never includes it, so there are **no holes and no stuck cursors**. Treat rules as a backstop for fan-out queries: the query should already narrow to authorized index ranges.
+
+## Codec fields as merge-order keys are forbidden
+
+`zodvexMergedStream` throws if any field in `orderByIndexFields` is codec-backed (e.g. a `zx.date()` field):
+
+```ts
+// ✗ throws — scheduledAt is a codec field
+zodvexMergedStream(substreams, ['scheduledAt'])
+
+// ✓ pin codec fields with .eq() inside each substream, order by non-codec fields
+zodvexMergedStream(substreams, ['_creationTime'])
+```
+
+The merge comparator reads index-key values off the *yielded* (decoded) documents, while the underlying Convex index is ordered by *wire* values — decoded comparisons can mis-order the merge, and decoded values (like `Date`) are not serializable into pagination cursors.
+
+The same caution applies to paginating a single stream whose index range is *bounded* (not `.eq()`-pinned) on a codec field: cursors serialize index-key values from decoded docs. Prefer indexes whose ordering tail is non-codec (`_creationTime` is always safe).
+
+## API
+
+| Export | Description |
+| --- | --- |
+| `zodvexStream(db, schema)` | Typed `stream()` over the secure reader. Returns a `ZodvexStreamDatabaseReader`. |
+| `zodvexMergedStream(streams, orderByIndexFields)` | Typed `mergedStream()` with the codec merge-key guard. Returns a `ZodvexQueryStream<T>`. |
+| `ZodvexQueryStream<T>` | A convex-helpers `QueryStream` with decoded item types — supports `paginate`, `collect`, `take`, `first`, `unique`, `filterWith`, `map`, `distinct`, and async iteration. |
+| `ZodvexStreamDatabaseReader` / `ZodvexStreamQueryInitializer` / `ZodvexStreamQuery` / `ZodvexOrderedStreamQuery` | The typed fluent surface mirroring convex-helpers' stream classes. |
+
+Streams compose with everything `QueryStream` supports — `filterWith` for TypeScript-side filtering (still counts as read bandwidth), `map`, `distinct` for loose index scans — all yielding decoded documents.

--- a/examples/task-manager-mini/convex/_zodvex/api.js
+++ b/examples/task-manager-mini/convex/_zodvex/api.js
@@ -140,6 +140,10 @@ export const zodvexRegistry = {
     args: z.object({ after: zx.date() }),
     returns: z.array(z.object({ title: z.string(), description: z.optional(z.string()), status: z.enum(["todo", "in_progress", "done"]), priority: z.nullable(z.enum(["low", "medium", "high"])), ownerId: zx.id("users"), assigneeId: z.optional(zx.id("users")), dueDate: z.optional(zx.date()), completedAt: z.optional(zx.date()), estimate: z.optional(zDuration), createdAt: zx.date(), _id: zx.id("tasks"), _creationTime: z.number() })),
   },
+  'tasks:listByStatuses': {
+    args: z.object({ statuses: z.array(z.enum(["todo", "in_progress", "done"])), paginationOpts: z.object({ numItems: z.number(), cursor: z.nullable(z.string()) }) }),
+    returns: TaskModel.schema.paginatedDoc,
+  },
   'tasks:update': {
     args: z.object({ id: zx.id("tasks"), title: z.optional(z.string()), description: z.optional(z.string()), status: z.optional(z.enum(["todo", "in_progress", "done"])), priority: z.optional(z.nullable(z.enum(["low", "medium", "high"]))), assigneeId: z.optional(zx.id("users")), dueDate: z.optional(zx.date()), estimate: z.optional(zDuration) }),
     returns: undefined,

--- a/examples/task-manager-mini/convex/tasks.ts
+++ b/examples/task-manager-mini/convex/tasks.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod/mini'
 import { zx } from 'zodvex/mini'
+import { zodvexMergedStream, zodvexStream } from 'zodvex/mini/server'
 import type { Id } from './_generated/dataModel'
 import type { QueryCtx } from './_zodvex/server'
 import { zq, zm } from './functions'
 import { TaskModel } from './models/task'
 import { zDuration } from './codecs'
+import schema from './schema'
 
 /**
  * Read-only helper typed as `QueryCtx`. Used by both `get` (a query) and
@@ -57,6 +59,30 @@ export const listByCreated = zq({
       .collect()
   },
   returns: z.array(TaskModel.schema.doc),
+})
+
+/**
+ * Honest pagination over a set-valued predicate (`status IN {...}`) via
+ * zodvexStream / zodvexMergedStream (#78) — mini flavor.
+ */
+export const listByStatuses = zq({
+  args: {
+    statuses: z.array(z.enum(['todo', 'in_progress', 'done'])),
+    paginationOpts: z.object({
+      numItems: z.number(),
+      cursor: z.nullable(z.string()),
+    }),
+  },
+  handler: async (ctx, { statuses, paginationOpts }) => {
+    const substreams = statuses.map((status) =>
+      zodvexStream(ctx.db, schema)
+        .query('tasks')
+        .withIndex('by_status', (q) => q.eq('status', status))
+        .order('desc')
+    )
+    return await zodvexMergedStream(substreams, ['_creationTime']).paginate(paginationOpts)
+  },
+  returns: TaskModel.schema.paginatedDoc,
 })
 
 export const create = zm({

--- a/examples/task-manager-mini/test/smoke.ts
+++ b/examples/task-manager-mini/test/smoke.ts
@@ -135,6 +135,32 @@ async function main() {
   assert(taskPage.page !== undefined, 'paginated result has page')
   assert(taskPage.page.length >= 1, 'at least one task in page')
 
+  // Merged-stream pagination across statuses (zodvexStream/zodvexMergedStream, #78)
+  const streamTaskId = await client.mutation(api.tasks.create, {
+    title: 'Smoke Stream Task',
+    ownerId: userId,
+    status: 'in_progress',
+  })
+  assert(typeof streamTaskId === 'string', `stream task created: ${streamTaskId}`)
+
+  const streamArgs = { statuses: ['in_progress', 'done'] as ('in_progress' | 'done')[] }
+  const streamPage1 = await client.query(api.tasks.listByStatuses, {
+    ...streamArgs,
+    paginationOpts: { numItems: 1, cursor: null },
+  })
+  assert(streamPage1.page.length === 1, 'merged stream first page has exactly 1 item')
+  assert(streamPage1.isDone === false, 'merged stream reports more pages')
+
+  const streamPage2 = await client.query(api.tasks.listByStatuses, {
+    ...streamArgs,
+    paginationOpts: { numItems: 100, cursor: streamPage1.continueCursor },
+  })
+  assert(streamPage2.page.length >= 1, 'merged stream cursor page has items')
+  const streamIds = [...streamPage1.page, ...streamPage2.page].map((t) => t._id)
+  assert(streamIds.includes(streamTaskId), 'merged stream includes in_progress task')
+  assert(streamIds.includes(taskId), 'merged stream includes done task')
+  assert(new Set(streamIds).size === streamIds.length, 'merged stream pages do not overlap')
+
   // --- Summary ---
   console.log(`\n=== Results: ${passed} passed, ${failed} failed ===\n`)
   process.exit(failed > 0 ? 1 : 0)

--- a/examples/task-manager/convex/_zodvex/api.js
+++ b/examples/task-manager/convex/_zodvex/api.js
@@ -148,6 +148,10 @@ export const zodvexRegistry = {
     args: z.object({ after: zx.date() }),
     returns: z.array(z.object({ title: z.string(), description: z.string().optional(), status: z.enum(["todo", "in_progress", "done"]), priority: z.enum(["low", "medium", "high"]).nullable(), ownerId: zx.id("users"), assigneeId: zx.id("users").optional(), dueDate: zx.date().optional(), completedAt: zx.date().optional(), estimate: zDuration.optional(), createdAt: zx.date(), _id: zx.id("tasks"), _creationTime: z.number() })),
   },
+  'tasks:listByStatuses': {
+    args: z.object({ statuses: z.array(z.enum(["todo", "in_progress", "done"])), paginationOpts: z.object({ numItems: z.number(), cursor: z.string().nullable() }) }),
+    returns: TaskModel.schema.paginatedDoc,
+  },
   'tasks:update': {
     args: z.object({ id: zx.id("tasks"), title: z.string().optional(), description: z.string().optional(), status: z.enum(["todo", "in_progress", "done"]).optional(), priority: z.enum(["low", "medium", "high"]).nullable().optional(), assigneeId: zx.id("users").optional(), dueDate: zx.date().optional(), estimate: zDuration.optional() }),
     returns: undefined,

--- a/examples/task-manager/convex/tasks.ts
+++ b/examples/task-manager/convex/tasks.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod'
 import { zx } from 'zodvex'
+import { zodvexMergedStream, zodvexStream } from 'zodvex/server'
 import type { Id } from './_generated/dataModel'
 import type { QueryCtx } from './_zodvex/server'
 import { zq, zm } from './functions'
 import { TaskModel } from './models/task'
 import { zDuration } from './codecs'
+import schema from './schema'
 
 /**
  * Read-only helper typed as `QueryCtx`. Used by both `get` (a query) and
@@ -57,6 +59,33 @@ export const listByCreated = zq({
       .collect()
   },
   returns: z.array(TaskModel.schema.doc),
+})
+
+/**
+ * Honest pagination over a set-valued predicate (`status IN {...}`) via
+ * zodvexStream / zodvexMergedStream (#78): one substream per status over
+ * `by_status`, k-way merged on `_creationTime` with index-key cursors that
+ * stay valid across all substreams. Every streamed row flows through the
+ * codec decode chain (dueDate/createdAt arrive as Date).
+ */
+export const listByStatuses = zq({
+  args: {
+    statuses: z.array(z.enum(['todo', 'in_progress', 'done'])),
+    paginationOpts: z.object({
+      numItems: z.number(),
+      cursor: z.string().nullable(),
+    }),
+  },
+  handler: async (ctx, { statuses, paginationOpts }) => {
+    const substreams = statuses.map((status) =>
+      zodvexStream(ctx.db, schema)
+        .query('tasks')
+        .withIndex('by_status', (q) => q.eq('status', status))
+        .order('desc')
+    )
+    return await zodvexMergedStream(substreams, ['_creationTime']).paginate(paginationOpts)
+  },
+  returns: TaskModel.schema.paginatedDoc,
 })
 
 export const create = zm({

--- a/examples/task-manager/test/smoke.ts
+++ b/examples/task-manager/test/smoke.ts
@@ -135,6 +135,32 @@ async function main() {
   assert(taskPage.page !== undefined, 'paginated result has page')
   assert(taskPage.page.length >= 1, 'at least one task in page')
 
+  // Merged-stream pagination across statuses (zodvexStream/zodvexMergedStream, #78)
+  const streamTaskId = await client.mutation(api.tasks.create, {
+    title: 'Smoke Stream Task',
+    ownerId: userId,
+    status: 'in_progress',
+  })
+  assert(typeof streamTaskId === 'string', `stream task created: ${streamTaskId}`)
+
+  const streamArgs = { statuses: ['in_progress', 'done'] as ('in_progress' | 'done')[] }
+  const streamPage1 = await client.query(api.tasks.listByStatuses, {
+    ...streamArgs,
+    paginationOpts: { numItems: 1, cursor: null },
+  })
+  assert(streamPage1.page.length === 1, 'merged stream first page has exactly 1 item')
+  assert(streamPage1.isDone === false, 'merged stream reports more pages')
+
+  const streamPage2 = await client.query(api.tasks.listByStatuses, {
+    ...streamArgs,
+    paginationOpts: { numItems: 100, cursor: streamPage1.continueCursor },
+  })
+  assert(streamPage2.page.length >= 1, 'merged stream cursor page has items')
+  const streamIds = [...streamPage1.page, ...streamPage2.page].map((t) => t._id)
+  assert(streamIds.includes(streamTaskId), 'merged stream includes in_progress task')
+  assert(streamIds.includes(taskId), 'merged stream includes done task')
+  assert(new Set(streamIds).size === streamIds.length, 'merged stream pages do not overlap')
+
   // --- Summary ---
   console.log(`\n=== Results: ${passed} passed, ${failed} failed ===\n`)
   process.exit(failed > 0 ? 1 : 0)

--- a/packages/zodvex/__tests__/stream.test.ts
+++ b/packages/zodvex/__tests__/stream.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Tests for zodvexStream / zodvexMergedStream — typed convex-helpers stream
+ * interop for the secure DatabaseReader (#78).
+ *
+ * These tests pin the duck-typed surface that convex-helpers' stream() relies
+ * on — db.query(table).withIndex(...).order(...) plus async iteration — so a
+ * chain-surface change in zodvex fails loudly here instead of silently
+ * breaking downstream consumers.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { createZodDbReader } from '../src/internal/db'
+import { defineZodModel } from '../src/internal/model'
+import { defineZodSchema } from '../src/internal/schema'
+import { zodvexMergedStream, zodvexStream } from '../src/internal/stream'
+import { zx } from '../src/internal/zx'
+
+// ============================================================================
+// Fixture schema — visits table with a codec field and a multi-field index
+// ============================================================================
+
+const Visits = defineZodModel('visits', {
+  tenantId: z.string(),
+  roomId: z.string(),
+  note: z.string(),
+  scheduledAt: zx.date()
+})
+  .index('tenantId_roomId', ['tenantId', 'roomId'])
+  .index('by_scheduledAt', ['scheduledAt'])
+
+const schema = defineZodSchema({ visits: Visits })
+
+const wireVisits = [
+  {
+    _id: 'visits:1',
+    _creationTime: 100,
+    tenantId: 't1',
+    roomId: 'a',
+    note: 'a1',
+    scheduledAt: 1700000001000
+  },
+  {
+    _id: 'visits:2',
+    _creationTime: 200,
+    tenantId: 't1',
+    roomId: 'b',
+    note: 'b1',
+    scheduledAt: 1700000002000
+  },
+  {
+    _id: 'visits:3',
+    _creationTime: 300,
+    tenantId: 't1',
+    roomId: 'a',
+    note: 'a2',
+    scheduledAt: 1700000003000
+  },
+  {
+    _id: 'visits:4',
+    _creationTime: 400,
+    tenantId: 't1',
+    roomId: 'b',
+    note: 'b2',
+    scheduledAt: 1700000004000
+  },
+  {
+    _id: 'visits:5',
+    _creationTime: 500,
+    tenantId: 't2',
+    roomId: 'a',
+    note: 'other',
+    scheduledAt: 1700000005000
+  }
+]
+
+// Index fields as Convex resolves them (user fields + _creationTime + _id)
+const INDEX_FIELDS: Record<string, string[]> = {
+  by_id: ['_id'],
+  by_creation_time: ['_creationTime', '_id'],
+  tenantId_roomId: ['tenantId', 'roomId', '_creationTime', '_id'],
+  by_scheduledAt: ['scheduledAt', '_creationTime', '_id']
+}
+
+type Constraint = ['eq' | 'gt' | 'gte' | 'lt' | 'lte', string, any]
+
+function cmp(a: any, b: any): number {
+  if (a === b) return 0
+  return a < b ? -1 : 1
+}
+
+/**
+ * Mock raw Convex reader with real index semantics: withIndex captures
+ * range constraints, order sorts by the index's fields. This is the raw
+ * (wire-format) layer underneath the zodvex secure reader.
+ */
+function createIndexedMockDb(tables: Record<string, any[]>) {
+  const makeOrdered = (docs: any[], indexFields: string[], constraints: Constraint[]) => ({
+    order(order: 'asc' | 'desc') {
+      const filtered = docs
+        .filter(doc =>
+          constraints.every(([op, field, value]) => {
+            const c = cmp(doc[field], value)
+            if (op === 'eq') return c === 0
+            if (op === 'gt') return c > 0
+            if (op === 'gte') return c >= 0
+            if (op === 'lt') return c < 0
+            return c <= 0
+          })
+        )
+        .sort((d1, d2) => {
+          for (const f of indexFields) {
+            const c = cmp(d1[f], d2[f])
+            if (c !== 0) return c
+          }
+          return 0
+        })
+      if (order === 'desc') filtered.reverse()
+      return {
+        collect: async () => filtered,
+        [Symbol.asyncIterator]: async function* () {
+          for (const doc of filtered) yield doc
+        }
+      }
+    }
+  })
+
+  return {
+    system: { get: async () => null, query: () => ({}), normalizeId: () => null },
+    normalizeId: (tableName: string, id: string) => (id.startsWith(`${tableName}:`) ? id : null),
+    get: async (id: string) => {
+      for (const docs of Object.values(tables)) {
+        const doc = docs.find((d: any) => d._id === id)
+        if (doc) return doc
+      }
+      return null
+    },
+    query: (tableName: string) => {
+      const docs = tables[tableName] ?? []
+      return {
+        withIndex(indexName: string, rangeFn?: (q: any) => any) {
+          const indexFields = INDEX_FIELDS[indexName]
+          if (!indexFields) throw new Error(`mock: unknown index ${indexName}`)
+          const constraints: Constraint[] = []
+          const builder: any = {}
+          for (const op of ['eq', 'gt', 'gte', 'lt', 'lte'] as const) {
+            builder[op] = (field: string, value: any) => {
+              constraints.push([op, field, value])
+              return builder
+            }
+          }
+          rangeFn?.(builder)
+          return makeOrdered(docs, indexFields, constraints)
+        },
+        fullTableScan() {
+          return makeOrdered(docs, INDEX_FIELDS.by_creation_time, [])
+        }
+      }
+    }
+  }
+}
+
+function createReader() {
+  const rawDb = createIndexedMockDb({ visits: wireVisits })
+  return createZodDbReader(rawDb as any, schema)
+}
+
+// ============================================================================
+// zodvexStream — typed stream over the secure reader
+// ============================================================================
+
+describe('zodvexStream', () => {
+  it('streams decoded docs through the secure reader (pins the duck-typed surface)', async () => {
+    const reader = createReader()
+    const docs = await zodvexStream(reader, schema)
+      .query('visits')
+      .withIndex('tenantId_roomId', q => q.eq('tenantId', 't1').eq('roomId', 'a'))
+      .order('asc')
+      .collect()
+
+    expect(docs.map((d: any) => d.note)).toEqual(['a1', 'a2'])
+    // Streamed rows flow through the codec decode chain
+    expect(docs[0].scheduledAt).toBeInstanceOf(Date)
+    expect((docs[0].scheduledAt as Date).getTime()).toBe(1700000001000)
+  })
+
+  it('async-iterates decoded docs', async () => {
+    const reader = createReader()
+    const s = zodvexStream(reader, schema)
+      .query('visits')
+      .withIndex('tenantId_roomId', q => q.eq('tenantId', 't1').eq('roomId', 'b'))
+      .order('asc')
+
+    const notes: string[] = []
+    for await (const doc of s) {
+      notes.push(doc.note)
+      expect(doc.scheduledAt).toBeInstanceOf(Date)
+    }
+    expect(notes).toEqual(['b1', 'b2'])
+  })
+
+  it('first()/take() return decoded docs', async () => {
+    const reader = createReader()
+    const s = zodvexStream(reader, schema)
+      .query('visits')
+      .withIndex('tenantId_roomId', q => q.eq('tenantId', 't1'))
+      .order('desc')
+
+    const first = await s.first()
+    expect(first?.note).toBe('b2')
+    expect(first?.scheduledAt).toBeInstanceOf(Date)
+  })
+
+  it('paginate() on a single stream returns decoded pages with working cursors', async () => {
+    const reader = createReader()
+    const makeStream = () =>
+      zodvexStream(reader, schema)
+        .query('visits')
+        .withIndex('tenantId_roomId', q => q.eq('tenantId', 't1'))
+        .order('asc')
+
+    // Index order with only tenantId pinned: by roomId, then _creationTime
+    const page1 = await makeStream().paginate({ numItems: 3, cursor: null })
+    expect(page1.page.map((d: any) => d.note)).toEqual(['a1', 'a2', 'b1'])
+    expect(page1.page[0].scheduledAt).toBeInstanceOf(Date)
+    expect(page1.isDone).toBe(false)
+
+    const page2 = await makeStream().paginate({ numItems: 10, cursor: page1.continueCursor })
+    expect(page2.page.map((d: any) => d.note)).toEqual(['b2'])
+    expect(page2.isDone).toBe(true)
+  })
+
+  it('preserves read rules: denied rows are skipped mid-stream without holes', async () => {
+    const reader = createReader().withRules(
+      {},
+      {
+        visits: {
+          read: async (_ctx: any, doc: any) => (doc.roomId === 'a' ? doc : null)
+        }
+      }
+    )
+
+    const docs = await zodvexStream(reader, schema)
+      .query('visits')
+      .withIndex('tenantId_roomId', q => q.eq('tenantId', 't1'))
+      .order('asc')
+      .collect()
+
+    expect(docs.map((d: any) => d.note)).toEqual(['a1', 'a2'])
+  })
+})
+
+// ============================================================================
+// zodvexMergedStream — k-way merge over substreams
+// ============================================================================
+
+describe('zodvexMergedStream', () => {
+  it('merges fan-out substreams and paginates with index-key cursors', async () => {
+    const reader = createReader()
+    const makeSubstreams = () =>
+      ['a', 'b'].map(roomId =>
+        zodvexStream(reader, schema)
+          .query('visits')
+          .withIndex('tenantId_roomId', q => q.eq('tenantId', 't1').eq('roomId', roomId))
+          .order('asc')
+      )
+
+    const page1 = await zodvexMergedStream(makeSubstreams(), ['_creationTime']).paginate({
+      numItems: 2,
+      cursor: null
+    })
+    expect(page1.page.map((d: any) => d.note)).toEqual(['a1', 'b1'])
+    expect(page1.page[0].scheduledAt).toBeInstanceOf(Date)
+    expect(page1.isDone).toBe(false)
+
+    const page2 = await zodvexMergedStream(makeSubstreams(), ['_creationTime']).paginate({
+      numItems: 10,
+      cursor: page1.continueCursor
+    })
+    expect(page2.page.map((d: any) => d.note)).toEqual(['a2', 'b2'])
+    expect(page2.isDone).toBe(true)
+  })
+
+  it('merge respects rules: denied rows never enter the merged cursor space', async () => {
+    const reader = createReader().withRules(
+      {},
+      {
+        visits: {
+          read: async (_ctx: any, doc: any) => (doc.note === 'b1' ? null : doc)
+        }
+      }
+    )
+    const substreams = ['a', 'b'].map(roomId =>
+      zodvexStream(reader, schema)
+        .query('visits')
+        .withIndex('tenantId_roomId', q => q.eq('tenantId', 't1').eq('roomId', roomId))
+        .order('asc')
+    )
+
+    const docs = await zodvexMergedStream(substreams, ['_creationTime']).collect()
+    expect(docs.map((d: any) => d.note)).toEqual(['a1', 'a2', 'b2'])
+  })
+
+  it('forbids codec-backed fields in orderByIndexFields', () => {
+    const reader = createReader()
+    const substreams = ['a', 'b'].map(() =>
+      zodvexStream(reader, schema).query('visits').withIndex('by_scheduledAt').order('asc')
+    )
+
+    expect(() => zodvexMergedStream(substreams, ['scheduledAt'])).toThrow(/codec-backed/i)
+  })
+
+  it('allows non-codec orderByIndexFields on tables that have codec fields elsewhere', () => {
+    const reader = createReader()
+    const substreams = ['a', 'b'].map(roomId =>
+      zodvexStream(reader, schema)
+        .query('visits')
+        .withIndex('tenantId_roomId', q => q.eq('tenantId', 't1').eq('roomId', roomId))
+        .order('asc')
+    )
+
+    expect(() => zodvexMergedStream(substreams, ['_creationTime'])).not.toThrow()
+  })
+})
+
+// ============================================================================
+// Type-level assertions — stream items are DECODED doc types
+// ============================================================================
+
+type AssertAssignable<A, B> = A extends B ? true : false
+
+async function _typeOnly() {
+  const reader = createReader()
+  const s = zodvexStream(reader, schema)
+    .query('visits')
+    .withIndex('tenantId_roomId', q => q.eq('tenantId', 't1'))
+    .order('asc')
+
+  const docs = await s.collect()
+  // scheduledAt is the decoded (runtime) type — Date, not the wire number
+  type _scheduledAtIsDate = AssertAssignable<(typeof docs)[number]['scheduledAt'], Date>
+  const _check1: _scheduledAtIsDate = true
+
+  const merged = zodvexMergedStream([s], ['_creationTime'])
+  const page = await merged.paginate({ numItems: 1, cursor: null })
+  type _pageIsDecoded = AssertAssignable<(typeof page.page)[number]['scheduledAt'], Date>
+  const _check2: _pageIsDecoded = true
+
+  return [_check1, _check2]
+}
+void _typeOnly

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.5",
+  "version": "0.7.6-beta.0",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.6-beta.0",
+  "version": "0.7.6",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",

--- a/packages/zodvex/src/internal/db.ts
+++ b/packages/zodvex/src/internal/db.ts
@@ -408,7 +408,7 @@ export class ZodvexQueryChain<TableInfo extends GenericTableInfo, Doc = Document
  * If the table has a decoded type in DecodedDocs, use it.
  * Otherwise fall back to DocumentByInfo (wire types = runtime types for tables without codecs).
  */
-type ResolveDecodedDoc<
+export type ResolveDecodedDoc<
   DataModel extends GenericDataModel,
   DecodedDocs extends Record<string, any>,
   TableName extends TableNamesInDataModel<DataModel>

--- a/packages/zodvex/src/internal/stream.ts
+++ b/packages/zodvex/src/internal/stream.ts
@@ -1,0 +1,242 @@
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByInfo,
+  GenericDatabaseReader,
+  GenericTableInfo,
+  IndexNames,
+  IndexRange,
+  NamedIndex,
+  NamedTableInfo,
+  SchemaDefinition,
+  TableNamesInDataModel
+} from 'convex/server'
+import { mergedStream, type QueryStream, stream } from 'convex-helpers/server/stream'
+import type { ResolveDecodedDoc, ZodvexDatabaseReader, ZodvexIndexRangeBuilder } from './db'
+import type { ZodTableMap } from './schema'
+import {
+  $ZodCodec,
+  $ZodDefault,
+  $ZodNullable,
+  $ZodObject,
+  $ZodOptional,
+  $ZodType,
+  $ZodUnion
+} from './zod-core'
+
+/**
+ * Typed convex-helpers stream interop for the secure DatabaseReader (#78).
+ *
+ * convex-helpers' `stream()` / `mergedStream()` enable honest pagination over
+ * set-valued equality predicates (`roomId IN {a, b, c}`): fan out one
+ * substream per value over an index and k-way merge them with index-key
+ * cursors that stay valid across all substreams.
+ *
+ * `stream()` nominally requires a `GenericDatabaseReader`, which the zodvex
+ * secure reader doesn't implement (its `query()` returns the decoded chain).
+ * This module provides the typed entry point so call sites never cast:
+ *
+ * - The unavoidable cast lives in ONE audited place (`zodvexStream`), pinned
+ *   by tests that exercise the duck-typed surface stream() relies on
+ *   (`db.query(table).withIndex(...).order(...)` + async iteration), so a
+ *   chain-surface change fails loudly in zodvex CI rather than silently
+ *   downstream.
+ * - Item/page types are the DECODED doc types (codec outputs applied), which
+ *   is what the zodvex chain actually yields — not convex-helpers' raw
+ *   `DocumentByName` types.
+ *
+ * Rules semantics: streams are rules-preserving. Every streamed row flows
+ * through the secure chain (decode + read rules evaluated per row
+ * mid-stream). If a read rule denies a row inside a substream, the row is
+ * simply never yielded — the merged index-key cursor never includes it, so
+ * there are no holes and no stuck cursors. Rules act as a backstop; fan-out
+ * queries should already narrow to authorized index ranges.
+ */
+
+/** Convex stream items must be non-nullish (mirrors convex-helpers' unexported GenericStreamItem). */
+type StreamItem = NonNullable<unknown>
+
+/**
+ * A stream of DECODED documents. Alias of convex-helpers' `QueryStream` with
+ * the item type corrected to what the zodvex chain actually yields, so
+ * `paginate()` / `collect()` / iteration return decoded docs.
+ */
+export type ZodvexQueryStream<T extends StreamItem> = QueryStream<T>
+
+/** Ordered stream over decoded documents — mergeable and paginatable. */
+export interface ZodvexOrderedStreamQuery<T extends StreamItem> extends QueryStream<T> {}
+
+/** Stream query with an index applied; `.order()` yields the mergeable stream. */
+export interface ZodvexStreamQuery<T extends StreamItem> extends QueryStream<T> {
+  order(order: 'asc' | 'desc'): ZodvexOrderedStreamQuery<T>
+}
+
+/**
+ * Entry point for a single table's stream. Mirrors convex-helpers'
+ * `StreamQueryInitializer` surface, but `withIndex` uses zodvex's
+ * decoded-aware index range builder (codec fields accept decoded values,
+ * e.g. Date) and terminal types are decoded docs.
+ */
+export interface ZodvexStreamQueryInitializer<
+  TableInfo extends GenericTableInfo,
+  T extends StreamItem
+> extends ZodvexStreamQuery<T> {
+  fullTableScan(): ZodvexStreamQuery<T>
+  withIndex<IndexName extends IndexNames<TableInfo>>(
+    indexName: IndexName,
+    indexRange?: (
+      q: ZodvexIndexRangeBuilder<DocumentByInfo<TableInfo>, T, NamedIndex<TableInfo, IndexName>>
+    ) => IndexRange
+  ): ZodvexStreamQuery<T>
+}
+
+/** A defineZodSchema() result — a Convex schema carrying the zod table map. */
+export type ZodvexStreamableSchema = SchemaDefinition<any, boolean> & {
+  __zodTableMap: ZodTableMap
+}
+
+/** Extracts the phantom decoded-doc map carried by defineZodSchema results. */
+type DecodedDocsOf<Schema> = Schema extends { __decodedDocs: infer DD extends Record<string, any> }
+  ? DD
+  : Record<string, any>
+
+/**
+ * The stream-flavored secure reader: same fluent surface as convex-helpers'
+ * `stream(db, schema)`, typed against decoded documents.
+ */
+export interface ZodvexStreamDatabaseReader<Schema extends ZodvexStreamableSchema> {
+  query<TableName extends TableNamesInDataModel<DataModelFromSchemaDefinition<Schema>>>(
+    tableName: TableName
+  ): ZodvexStreamQueryInitializer<
+    NamedTableInfo<DataModelFromSchemaDefinition<Schema>, TableName>,
+    NonNullable<
+      ResolveDecodedDoc<DataModelFromSchemaDefinition<Schema>, DecodedDocsOf<Schema>, TableName>
+    >
+  >
+}
+
+/**
+ * Creates a typed convex-helpers stream over the zodvex secure reader —
+ * no cast at call sites.
+ *
+ * Every streamed row flows through the secure chain: codec decode plus any
+ * read rules / audit wrappers attached to the reader. Use with
+ * `zodvexMergedStream` to paginate fan-out queries over set-valued equality
+ * predicates.
+ *
+ * @example
+ * ```ts
+ * const substreams = rooms.map(roomId =>
+ *   zodvexStream(ctx.db, schema)
+ *     .query('visits')
+ *     .withIndex('tenantId_roomId_status', q => q.eq('tenantId', tenantId).eq('roomId', roomId))
+ *     .order('asc')
+ * )
+ * return zodvexMergedStream(substreams, ['status', '_creationTime']).paginate(opts)
+ * ```
+ */
+export function zodvexStream<Schema extends ZodvexStreamableSchema>(
+  db: ZodvexDatabaseReader<DataModelFromSchemaDefinition<Schema>, any>,
+  schema: Schema
+): ZodvexStreamDatabaseReader<Schema> {
+  // THE one audited cast (#78). The secure reader doesn't nominally implement
+  // GenericDatabaseReader, but it is duck-type compatible with the surface
+  // stream() uses: db.query(table).withIndex(index, range).order(order) plus
+  // async iteration. That surface is pinned by __tests__/stream.test.ts.
+  const rawDb = db as unknown as GenericDatabaseReader<DataModelFromSchemaDefinition<Schema>>
+  return stream(rawDb, schema) as unknown as ZodvexStreamDatabaseReader<Schema>
+}
+
+/**
+ * Merge multiple zodvex streams into a single stream ordered by
+ * `orderByIndexFields`, suitable for `.paginate()` with cursors that stay
+ * valid across all substreams. Thin wrapper over convex-helpers'
+ * `mergedStream` that keeps decoded item types and rejects codec-backed
+ * merge keys.
+ *
+ * Codec-backed fields are FORBIDDEN in `orderByIndexFields`: the merge
+ * comparator reads index-key values off the yielded (decoded) documents,
+ * while the underlying Convex index is ordered by wire values — decoded
+ * comparisons can mis-order the merge and produce invalid cursors. Pin codec
+ * fields with `.eq()` inside each substream and order by non-codec fields
+ * (e.g. '_creationTime') instead.
+ */
+export function zodvexMergedStream<T extends StreamItem>(
+  streams: ZodvexQueryStream<T>[],
+  orderByIndexFields: string[]
+): ZodvexQueryStream<T> {
+  assertNoCodecOrderFields(streams, orderByIndexFields)
+  return mergedStream(streams, orderByIndexFields)
+}
+
+/** Unwraps Optional/Nullable/Default wrappers to reach the structural type. */
+function unwrapOuter(schema: $ZodType): $ZodType {
+  let current: $ZodType = schema
+  for (let i = 0; i < 10; i++) {
+    if (
+      current instanceof $ZodOptional ||
+      current instanceof $ZodNullable ||
+      current instanceof $ZodDefault
+    ) {
+      current = current._zod.def.innerType
+      continue
+    }
+    break
+  }
+  return current
+}
+
+/**
+ * Walks a (possibly dot-separated) field path through a doc schema and
+ * reports whether it crosses a codec boundary — i.e. whether the decoded
+ * value at that path differs from the wire value the index is ordered by.
+ * Union doc schemas (union tables) flag the field if ANY variant is
+ * codec-backed.
+ */
+function fieldIsCodecBacked(schema: $ZodType, segments: string[]): boolean {
+  const current = unwrapOuter(schema)
+  if (current instanceof $ZodCodec) return true
+  if (segments.length === 0) return false
+  if (current instanceof $ZodObject) {
+    const fieldSchema = (current._zod.def.shape as Record<string, $ZodType | undefined>)[
+      segments[0]
+    ]
+    return fieldSchema ? fieldIsCodecBacked(fieldSchema, segments.slice(1)) : false
+  }
+  if (current instanceof $ZodUnion) {
+    const options = current._zod.def.options as readonly $ZodType[]
+    return options.some(option => fieldIsCodecBacked(option, segments))
+  }
+  return false
+}
+
+/**
+ * Best-effort guard: for every stream that exposes `reflect()` (any stream
+ * built via zodvexStream(...).query(...)), look up the table's doc schema in
+ * the zodvex table map and reject codec-backed `orderByIndexFields`.
+ * Derived streams (filterWith/map) don't reflect and pass through unchecked.
+ */
+function assertNoCodecOrderFields(
+  streams: ZodvexQueryStream<any>[],
+  orderByIndexFields: string[]
+): void {
+  for (const s of streams) {
+    const reflect = (s as { reflect?: () => { schema?: unknown; table?: string } }).reflect
+    if (typeof reflect !== 'function') continue
+    const { schema, table } = reflect.call(s) ?? {}
+    const tableMap = (schema as { __zodTableMap?: ZodTableMap } | undefined)?.__zodTableMap
+    const docSchema = table ? tableMap?.[table]?.doc : undefined
+    if (!docSchema) continue
+    for (const field of orderByIndexFields) {
+      if (field === '_creationTime' || field === '_id') continue
+      if (fieldIsCodecBacked(docSchema, field.split('.'))) {
+        throw new Error(
+          `zodvexMergedStream: orderByIndexFields contains codec-backed field '${field}' ` +
+            `(table '${table}'). The merge comparator reads decoded values off yielded docs, ` +
+            `but the underlying index is ordered by wire values — codec-backed merge keys can ` +
+            `mis-order results and produce invalid cursors. Pin codec fields with .eq() inside ` +
+            `each substream and order by non-codec fields (e.g. '_creationTime') instead.`
+        )
+      }
+    }
+  }
+}

--- a/packages/zodvex/src/public/server/index.ts
+++ b/packages/zodvex/src/public/server/index.ts
@@ -77,5 +77,16 @@ export type {
 export * from '../../internal/schema'
 // Schema helpers (pure Zod, no server deps)
 export { addSystemFields } from '../../internal/schemaHelpers'
+// Typed convex-helpers stream interop for the secure reader (#78)
+export {
+  type ZodvexOrderedStreamQuery,
+  type ZodvexQueryStream,
+  type ZodvexStreamableSchema,
+  type ZodvexStreamDatabaseReader,
+  type ZodvexStreamQuery,
+  type ZodvexStreamQueryInitializer,
+  zodvexMergedStream,
+  zodvexStream
+} from '../../internal/stream'
 // Table creation and helpers (named — hide union internals)
 export { zodDoc, zodDocOrNull, zodTable } from '../../legacy/tables'


### PR DESCRIPTION
## Summary

Implements #78: a typed entry point into `convex-helpers/server/stream` for the zodvex secure `ctx.db`, targeting **0.7.6**.

> Originally stacked on #77 (0.7.5); now rebased onto `main` after the #77 squash-merge and 0.7.5 release.

- **`zodvexStream(db, schema)`** — no more double-casting the secure reader at call sites. The unavoidable cast lives in one audited place inside zodvex, pinned by `__tests__/stream.test.ts` exercising the duck-typed surface `stream()` relies on (`db.query(table).withIndex(...).order(...)` + async iteration), so a chain-surface change fails loudly in zodvex CI rather than silently downstream.
- **Decoded doc types end to end** — streamed items and `paginate()` pages are typed as the decoded docs the chain actually yields (e.g. `Date`, not wire `number`), fixing type lie #2 from the issue. `withIndex` uses zodvex's decoded-aware index range builder.
- **`zodvexMergedStream(streams, orderByIndexFields)`** — typed merge with a runtime guard **forbidding codec-backed merge-order keys**: the merge comparator reads index-key values off yielded (decoded) docs while the underlying index is ordered by wire values, so codec keys can mis-order the merge and produce unserializable cursors. (Settles the open design question from the issue in the "forbid" direction.)
- **Rules-denied-row semantics documented** ([docs/guide/streams.md](docs/guide/streams.md)): streams are rules-preserving — read rules evaluate per row mid-stream, and denied rows never enter the merged cursor space (no holes, no stuck cursors).
- Exported from `zodvex/server` and `zodvex/mini/server`; CHANGELOG entry under Unreleased (0.7.6); `listByStatuses` fan-out query added to both task-manager examples + network smoke tests.

## Test plan

- [x] `bun run lint` (incl. source-boundary guard)
- [x] `bun run type-check`
- [x] `bun run test` — 2080 passed, incl. 18 new stream tests (zod + zod-mini projects): duck-typed surface pin, decode-through-stream, single-stream and merged pagination with real index-key cursors, rules-denied rows skipped without cursor holes, codec merge-key rejection, type-level decoded-doc assertions
- [x] `bun run verify:consumer-declarations`
- [x] `bun run build`
- [x] `bun run verify:examples` — both examples typecheck the new `listByStatuses` stream query against their real generated data models; codegen regenerated
- [ ] `bun run verify:examples:network` — needs the configured Convex dev deployments (`.env.local` not present in this worktree); smoke tests now exercise merged-stream pagination with cursor continuation on real Convex

🤖 Generated with [Claude Code](https://claude.com/claude-code)
