### PR TITLE
fix(db): preserve top-level undefined in patch so fields can be unset (#82)

### DIFF
--- a/examples/task-manager/convex/patchUnset.test.ts
+++ b/examples/task-manager/convex/patchUnset.test.ts
@@ -1,0 +1,82 @@
+import { convexTest } from 'convex-test'
+import { describe, expect, test } from 'vitest'
+import { createZodDbWriter } from 'zodvex/server'
+import schema from './schema'
+
+const modules = import.meta.glob('./**/*.ts')
+
+/**
+ * End-to-end coverage for issue #82: the zodvex secure writer must let a
+ * `patch(id, { field: undefined })` delete an optional field, matching native
+ * Convex `patch` semantics. Previously `stripUndefined` dropped the key before
+ * Convex saw it, turning an intended unset into a silent no-op.
+ *
+ * These run against convex-test's emulated backend through the real secure
+ * writer (createZodDbWriter → encodePartialDoc → db.patch).
+ */
+describe('secure writer patch can unset optional fields (issue #82)', () => {
+  async function seedTask(t: ReturnType<typeof convexTest>, extra: Record<string, unknown>) {
+    return await t.run(async (ctx) => {
+      const ownerId = await ctx.db.insert('users', {
+        name: 'Alice',
+        email: { value: 'alice@test.com', tag: 'test' },
+        createdAt: Date.now(),
+      } as any)
+      return await ctx.db.insert('tasks', {
+        title: 'T',
+        status: 'todo',
+        priority: null,
+        ownerId,
+        createdAt: Date.now(),
+        ...extra,
+      } as any)
+    })
+  }
+
+  test('deletes a plain optional field (description)', async () => {
+    const t = convexTest(schema, modules)
+    const id = await seedTask(t, { description: 'temporary note' })
+
+    await t.run(async (ctx) => {
+      const before = await ctx.db.get(id)
+      expect((before as any).description).toBe('temporary note')
+
+      const zdb = createZodDbWriter(ctx.db as any, schema as any)
+      await zdb.patch(id as any, { description: undefined } as any)
+
+      const after = await ctx.db.get(id)
+      expect('description' in (after as any)).toBe(false)
+    })
+  })
+
+  test('deletes an optional codec field (dueDate via zx.date)', async () => {
+    const t = convexTest(schema, modules)
+    const id = await seedTask(t, { dueDate: Date.now() })
+
+    await t.run(async (ctx) => {
+      const before = await ctx.db.get(id)
+      expect(typeof (before as any).dueDate).toBe('number')
+
+      const zdb = createZodDbWriter(ctx.db as any, schema as any)
+      await zdb.patch(id as any, { dueDate: undefined } as any)
+
+      const after = await ctx.db.get(id)
+      expect('dueDate' in (after as any)).toBe(false)
+    })
+  })
+
+  test('does not unset fields that are simply absent from the patch', async () => {
+    const t = convexTest(schema, modules)
+    const id = await seedTask(t, { description: 'keep me' })
+
+    await t.run(async (ctx) => {
+      const zdb = createZodDbWriter(ctx.db as any, schema as any)
+      // Patch a different field; `description` is absent (not undefined) — must remain.
+      await zdb.patch(id as any, { title: 'renamed' } as any)
+
+      const after = await ctx.db.get(id)
+      expect((after as any).title).toBe('renamed')
+      expect((after as any).description).toBe('keep me')
+    })
+  })
+})

--- a/packages/zodvex/__tests__/codec-doc.test.ts
+++ b/packages/zodvex/__tests__/codec-doc.test.ts
@@ -124,16 +124,40 @@ describe('encodePartialDoc', () => {
     expect(result).toEqual({ name: 'Updated Name', updatedAt: 1700000000000 })
   })
 
-  it('strips undefined values from partial', () => {
+  it('preserves top-level undefined so patch can delete the field (issue #82)', () => {
     const schema = z.object({
       name: z.string(),
       nickname: z.string().optional()
     })
 
+    // Top-level undefined is an intentional unset — it must survive so Convex's
+    // patch serializer turns it into a field delete ({ $undefined: null }).
     const result = encodePartialDoc(schema, { name: 'Alice', nickname: undefined })
 
-    expect(result).toEqual({ name: 'Alice' })
-    expect('nickname' in result).toBe(false)
+    expect('nickname' in result).toBe(true)
+    expect((result as any).nickname).toBe(undefined)
+    expect((result as any).name).toBe('Alice')
+  })
+
+  it('strips undefined nested inside a value (not a delete)', () => {
+    const schema = z.object({
+      name: z.string(),
+      profile: z.object({
+        bio: z.string().optional(),
+        handle: z.string()
+      })
+    })
+
+    const result = encodePartialDoc(schema, {
+      name: 'Alice',
+      profile: { bio: undefined, handle: 'alice' }
+    })
+
+    // Nested undefined is cleaned (it means "absent", not "delete a top-level field").
+    expect((result as any).profile).toEqual({ handle: 'alice' })
+    expect('bio' in (result as any).profile).toBe(false)
+    // But the top-level key is still preserved as a normal value.
+    expect((result as any).name).toBe('Alice')
   })
 
   it('handles empty partial', () => {

--- a/packages/zodvex/__tests__/db.test.ts
+++ b/packages/zodvex/__tests__/db.test.ts
@@ -340,6 +340,27 @@ describe('ZodvexDatabaseWriter', () => {
     expect(calls[0].args[1].createdAt).toBe(1800000000000)
   })
 
+  it('patch(id, { field: undefined }) forwards undefined so Convex deletes the field (issue #82)', async () => {
+    const { db: mockDb, calls } = createMockDbWriter(tableData)
+    // Schema with an optional field that a patch should be able to unset.
+    const tableMapWithOptional = {
+      users: {
+        ...userSchemas,
+        insert: userInsertSchema.extend({ nickname: z.string().optional() })
+      }
+    }
+    const db = new ZodvexDatabaseWriter(mockDb, tableMapWithOptional)
+
+    await db.patch('users:1' as any, { nickname: undefined } as any)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].method).toBe('patch')
+    const wireValue = calls[0].args[1]
+    // The undefined key must survive — Convex's patch turns it into a field delete.
+    expect('nickname' in wireValue).toBe(true)
+    expect(wireValue.nickname).toBe(undefined)
+  })
+
   it('replace(id, value) encodes full runtime document', async () => {
     const { db: mockDb, calls } = createMockDbWriter(tableData)
     const db = new ZodvexDatabaseWriter(mockDb, tableMap)

--- a/packages/zodvex/src/internal/codec.ts
+++ b/packages/zodvex/src/internal/codec.ts
@@ -73,8 +73,34 @@ export function encodeDoc<S extends $ZodType>(schema: S, runtimeDoc: zoutput<S>)
 }
 
 /**
+ * Strips `undefined` from nested values while preserving top-level `undefined` keys.
+ *
+ * This is the patch-specific counterpart to `stripUndefined`. On a Convex `patch`,
+ * a top-level field set to `undefined` is the documented way to *delete* that field
+ * (Convex serializes it to `{ $undefined: null }` via `patchValueToJson`). A blanket
+ * `stripUndefined` would drop that key before Convex ever sees it, turning an intended
+ * unset into a silent no-op (issue #82).
+ *
+ * So we keep top-level `undefined` keys intact (they reach Convex as deletes) but still
+ * clean `undefined` *inside* nested values — matching how `encodeDoc` treats stored
+ * values, where `undefined` means "absent" rather than "delete".
+ */
+function stripUndefinedPreservingTopLevel(value: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, val] of Object.entries(value)) {
+    // Top-level undefined = intentional field deletion — preserve it for Convex.
+    result[key] = val === undefined ? undefined : stripUndefined(val)
+  }
+  return result
+}
+
+/**
  * Encodes a partial runtime document to wire format (for Convex DB patch operations).
  * Only encodes the fields present in the partial. Uses schema.partial() + z.encode().
+ *
+ * Unlike `encodeDoc`, this preserves top-level `undefined` values so that
+ * `patch(id, { field: undefined })` deletes the field, matching native Convex
+ * `patch` semantics (issue #82). Nested `undefined` is still stripped.
  */
 export function encodePartialDoc<S extends $ZodType>(
   schema: S,
@@ -83,7 +109,13 @@ export function encodePartialDoc<S extends $ZodType>(
   if (!(schema instanceof $ZodObject)) {
     // For non-object schemas (unions, etc.), fall back to full encode
     // Cast needed: Partial<output<S>> is structurally compatible but not assignable to output<S>
-    return stripUndefined(encode(schema, partial as zoutput<S>)) as Partial<zinput<S>>
+    const encoded = encode(schema, partial as zoutput<S>)
+    // Top-level union docs are still objects — preserve top-level undefined for deletes.
+    return (
+      encoded !== null && typeof encoded === 'object' && !Array.isArray(encoded)
+        ? stripUndefinedPreservingTopLevel(encoded as Record<string, unknown>)
+        : stripUndefined(encoded)
+    ) as Partial<zinput<S>>
   }
   // Use manual shape wrapping instead of .partial() — not available on zod/mini
   const shape = (schema as any)._zod.def.shape
@@ -95,7 +127,8 @@ export function encodePartialDoc<S extends $ZodType>(
         : new $ZodOptional({ type: 'optional', innerType: value as any })
   }
   const partialSchema = z.object(partialShape)
-  return stripUndefined(encode(partialSchema, partial)) as Partial<zinput<S>>
+  const encoded = encode(partialSchema, partial) as Record<string, unknown>
+  return stripUndefinedPreservingTopLevel(encoded) as Partial<zinput<S>>
 }
 
 /**


### PR DESCRIPTION
Fixes #82.

## Problem

The secure `DatabaseWriter`'s `patch` ran the full `stripUndefined` on the partial before handing it to Convex, dropping any `undefined`-valued key. That silently overrode Convex's documented `patch` semantics: natively, a **top-level field set to `undefined` deletes that field**. Through the zodvex writer the key was stripped first, so an intended unset became a **no-op** — once an optional field was set, you could never return it to "absent".

## Root cause

`stripUndefined` was added for full-doc writes (`insert`/`replace`) and args/returns, where `undefined` means *"absent"* — there, stripping is correct and matches what Convex's serializer does anyway. The same strip was reused on the **patch** path, where `undefined` means *"delete"*. Same encode-preserved `undefined`, different meaning per operation. That's the bug — not a deliberate departure from the Convex API.

Verified empirically against Convex 1.32's serializer and `convex-test`:
- `patchValueToJson` (patch) turns a top-level `undefined` into `{ $undefined: null }` = delete.
- `convexToJson` (insert/replace/args/returns) silently drops object-field `undefined`.
- Convex only *throws* on `undefined` as an array element or whole value — cases `stripUndefined` doesn't address anyway.

So the strip on the patch path was redundant-to-harmful, and actively broke the delete capability.

## Fix

`encodePartialDoc` now preserves **top-level** `undefined` keys (intentional deletes that reach Convex as `{ $undefined: null }`) while still stripping `undefined` **nested inside** values (parity with `encodeDoc`). `insert`/`replace` and the args/returns paths are untouched. Required-field deletes are still rejected by the Convex backend.

```ts
// now matches native Convex — no new API needed
await ctx.db.patch(userId, { nickname: undefined })  // field removed
```

No `DELETE_FIELD` sentinel, no `unset()` helper — just native Convex semantics restored.

## Tests

- `codec-doc.test.ts` — top-level `undefined` preserved; nested `undefined` still stripped.
- `db.test.ts` — secure writer forwards `undefined` through to `db.patch`.
- `examples/task-manager/convex/patchUnset.test.ts` — `convex-test` e2e proving, against the emulated backend, that `patch(id, { field: undefined })` deletes a plain optional **and** an optional codec field (`zx.date`), and that a merely-absent field is *not* unset.

## Verification

- Full suite: 2084 tests pass (146 files)
- `type-check`: clean
- `lint`: clean (the 2 warnings are pre-existing, in an untouched test)

https://claude.ai/code/session_0156MgZsymyCxK8vFfXmVtjP

---
_Generated by [Claude Code](https://claude.ai/code/session_0156MgZsymyCxK8vFfXmVtjP)_