### PR TITLE
chore: bump version to 0.7.7-beta.1

### DIFF
--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.6",
+  "version": "0.7.7-beta.1",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",


### PR DESCRIPTION
Version bump for the 0.7.7 beta cut. Routed through a PR because `main` requires pull requests (the `bin/release-beta` direct-push flow needs maintainer bypass).

- `0.7.7-beta.0` is skipped: it was already published to npm on June 16 from the PR #83 branch trial (npm `beta` dist-tag currently points at it), so this cut takes `0.7.7-beta.1`.
- After merge, `v0.7.7-beta.1` will be tagged on the merge commit to trigger the release workflow (npm publish `--tag beta`).

Contents of this beta (all merged to main today): #86 (component-ref passthrough, fixes #85), #90 (customization args in function meta, fixes #88), #83 (patch can unset fields, fixes #82 — **behavior change**: top-level `undefined` in `patch` now deletes the field, matching native Convex), #93 (toJSONSchema codec handling, fixes #91; Node-compatible CLI, closes #89).

Release checks run locally on this exact base: lint, type-check, 2114 tests, build, verify:consumer-declarations, verify:examples, codegen freshness — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxFFSVKyCRL8vjbSP41hbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxFFSVKyCRL8vjbSP41hbQ)_