### PR TITLE
chore: bump version to 0.7.7-beta.2

### DIFF
--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.7-beta.1",
+  "version": "0.7.7-beta.2",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",


### PR DESCRIPTION
Version bump for the `0.7.7-beta.2` cut, routed through a PR per branch protection.

Contents on top of `beta.1`: #102 — the three fixes from hotpot's beta verification (tsconfig alias resolution under Node + strict discovery failures for #99, `zx.date()` runtime brand replacing the shape heuristic for #100, process-wide registry-miss warning dedup for #101).

After merge: push `release/v0.7.7-beta.2` at the merge commit → the release workflow creates the tag and publishes to npm with `--tag beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxFFSVKyCRL8vjbSP41hbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxFFSVKyCRL8vjbSP41hbQ)_