### PR TITLE
chore: bump version to 0.7.7

### DIFF
--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.7-beta.2",
+  "version": "0.7.7",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",


### PR DESCRIPTION
Stable `0.7.7` cut, routed through a PR per branch protection. Contents = the hotpot-verified `0.7.7-beta.2` plus one failure-path-only fix (#105, closing out #104).

## Release summary (since 0.7.6)

**Fixes**
- Component/raw function refs pass through codec-aware `runQuery`/`runMutation`/scheduler instead of throwing (#86, fixes #85)
- Customization args from `.withContext({ args })` are included in function meta and codegen registries — no more silent stripping of `_actor`-style args (#90, fixes #88)
- `patch(id, { field: undefined })` deletes the field through the secure writer, matching native Convex (#83, fixes #82). **Behavior change**: partials carrying accidental `undefined` used to no-op those keys and now delete them.
- `toJSONSchema` handles `zx.date()` (`date-time`) and generic codecs (wire side); user overrides run last and win (#93, fixes #91)
- CLI runs on stock Node: node shebang, loader hooks register under Node ESM, extensionless imports and tsconfig path aliases resolve, and any failed module import fails the generate instead of emitting a partial registry (#93 + #102, fixes #89/#99)
- `zx.date()` detected by runtime brand — shape-alike user codecs are no longer misidentified in `toJSONSchema` or codegen (#102, fixes #100)
- Registry-miss debug note logs once per path per process with accurate wording (#102, fixes #101)
- Failed generate restores the pre-existing registry instead of leaving the bootstrap stub (#105, fixes #104)

**Verification**: beta.1 and beta.2 both verified end-to-end downstream (hotpot) — CLI under Node byte-identical to Bun, component calls, `_actor` forwarding over `runMutation`/scheduler, patch-unset semantics, JSON Schema primitives, warning dedup, full regression sweep green.

After merge: push `release/v0.7.7` at the merge commit → the release workflow creates the tag and publishes to npm `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxFFSVKyCRL8vjbSP41hbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxFFSVKyCRL8vjbSP41hbQ)_