### PR TITLE
ci: harden release script, auto-create GitHub Releases for stables

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,0 +1,72 @@
+name: GitHub Release (existing tag)
+
+# Creates a GitHub Release for an ALREADY-PUBLISHED tag. The normal path is
+# automatic — release.yml creates the GitHub Release when a stable version
+# publishes. This workflow exists for two cases:
+#   1. Retroactive entries for tags that shipped before that automation.
+#   2. Environments that can't call the releases API directly (e.g. remote
+#      sandboxes on the repo's GitHub App credential, which can push branches
+#      but nothing else).
+# Trigger it by pushing a branch named gh-release/v<version> (any commit —
+# typically just main). The release body is docs/releases/v<version>.md when
+# present, with GitHub's auto-generated notes appended; the trigger branch is
+# deleted afterwards.
+
+on:
+  push:
+    branches:
+      - 'gh-release/v*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release for existing tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const tag = context.ref.replace('refs/heads/gh-release/', '');
+            // The tag must already exist — this workflow only writes the
+            // release entry; it never creates tags or publishes packages.
+            await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${tag}`,
+            });
+            const notesPath = `docs/releases/${tag}.md`;
+            const body = fs.existsSync(notesPath) ? fs.readFileSync(notesPath, 'utf8') : undefined;
+            try {
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                name: tag,
+                body,
+                prerelease: tag.includes('-'),
+                generate_release_notes: true,
+              });
+              core.info(`Created GitHub Release ${tag}`);
+            } catch (e) {
+              if (`${e}`.includes('already_exists')) {
+                core.info(`Release ${tag} already exists — nothing to do.`);
+              } else {
+                throw e;
+              }
+            }
+
+      - name: Delete trigger branch
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.ref.replace('refs/', ''),
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,39 @@ jobs:
           cd packages/zodvex
           npm publish --access public --provenance --tag "$DIST_TAG"
 
+      # Stable releases get a GitHub Release entry; prereleases don't. The
+      # body is docs/releases/<tag>.md when the repo carries one, and GitHub's
+      # auto-generated notes (PR list since the previous tag) are appended
+      # either way. Idempotent: an existing release is left untouched.
+      - name: Create GitHub Release (stable only)
+        if: steps.dist-tag.outputs.tag == 'latest'
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
+        with:
+          script: |
+            const fs = require('fs');
+            const tag = process.env.RELEASE_TAG;
+            const notesPath = `docs/releases/${tag}.md`;
+            const body = fs.existsSync(notesPath) ? fs.readFileSync(notesPath, 'utf8') : undefined;
+            try {
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                name: tag,
+                body,
+                generate_release_notes: true,
+              });
+              core.info(`Created GitHub Release ${tag}`);
+            } catch (e) {
+              if (`${e}`.includes('already_exists')) {
+                core.info(`Release ${tag} already exists — skipping.`);
+              } else {
+                throw e;
+              }
+            }
+
       - name: Delete release branch (release-branch path)
         if: startsWith(github.ref, 'refs/heads/release/')
         continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,13 +49,13 @@ All commands can be run from the repo root — they delegate to `packages/zodvex
 
 ### Releasing
 
-**Beta releases** (manual, fast):
-- `bin/release-beta` — auto-increments prerelease number, builds, tests, tags, pushes
-- `bin/release-beta 0.7.0-beta.0` — explicit version
-- Tag push triggers `.github/workflows/release.yml` → npm publish with `--tag beta`
-- No GitHub Release created for betas
+All releases go through `bin/release-beta` locally (runs the full check pipeline, bumps, commits, tags, pushes) and `.github/workflows/release.yml` in CI (tests, npm publish with the dist-tag derived from the version suffix, GitHub Release for stables). The script refuses to run off a clean, synced `main`.
 
-**Stable releases**: No automated stable release workflow yet. Stable releases are cut manually.
+- `bin/release-beta` — prerelease only: retries the current version if unpublished, else bumps the beta number. **Errors if the current version is stable** (an auto-increment would silently produce a stable publish to `latest`).
+- `bin/release-beta 0.8.0-beta.0` — explicit prerelease → npm `--tag beta`, no GitHub Release
+- `bin/release-beta 0.8.0 --stable` — explicit stable → npm `latest` + a GitHub Release (body from `docs/releases/v<version>.md` when present, auto-generated notes appended)
+
+**Tag-less environments** (e.g. remote sandboxes whose credential can push branches but not tags): after merging the version bump to main, push `release/v<version>` — `release.yml` verifies the version against `package.json`, creates the tag via `GITHUB_TOKEN`, publishes, and deletes the branch. `workflow_dispatch` with a `tag` input is equivalent. To add a GitHub Release entry for an already-published tag, push `gh-release/v<version>` (`.github/workflows/gh-release.yml`).
 
 **PR titles** must follow conventional commit format (`feat:`, `fix:`, `chore:`, etc.) — enforced by `.github/workflows/pr-title.yml`
 

--- a/bin/release-beta
+++ b/bin/release-beta
@@ -3,45 +3,95 @@ set -euo pipefail
 
 # Release script: fails fast on lint/type errors, then builds once before
 # running example verification that depends on the packaged exports.
-# Usage: bin/release <patch|minor|major|<explicit-version>>
 #
-# Examples:
-#   bin/release patch          # 0.6.0-beta.29 -> 0.6.0-beta.30
-#   bin/release 0.7.0          # set version explicitly
-#   bin/release                 # auto-increment prerelease number
+# Usage:
+#   bin/release-beta                          # prerelease only: retry current if
+#                                             # unpublished, else bump beta number
+#   bin/release-beta 0.8.0-beta.0             # explicit prerelease
+#   bin/release-beta 0.8.0 --stable           # explicit STABLE release (npm latest)
 #
-# Smart retry: if the current version in package.json was never published
-# to npm (e.g., previous CI failure), it re-uses that version instead of
-# burning a new number.
+# Version safety:
+#   - With no argument, the script only ever produces a PRERELEASE. If the
+#     current version is stable (e.g. 0.7.7), it refuses to guess — a bare
+#     auto-increment used to yield the next stable (0.7.8) and publish it to
+#     npm `latest` by accident.
+#   - A stable version (no -beta/-alpha/-rc suffix) always requires --stable.
+#
+# What happens after the push: the v<version> tag triggers
+# .github/workflows/release.yml, which tests, publishes to npm (dist-tag from
+# the suffix: -beta → beta, none → latest), and creates a GitHub Release for
+# stable versions. Environments that can't push tags have two equivalent
+# fallbacks built into that workflow: the workflow_dispatch trigger (tag
+# input) and pushing a `release/v<version>` branch. All paths verify the tag
+# against packages/zodvex/package.json before publishing.
 
 PKG="packages/zodvex/package.json"
-CURRENT=$(grep '"version"' "$PKG" | sed 's/.*": "\(.*\)".*/\1/')
 
+# --- Parse args ---
+EXPLICIT=""
+STABLE_FLAG=0
+for arg in "$@"; do
+  case "$arg" in
+    --stable) STABLE_FLAG=1 ;;
+    -*) echo "Unknown flag: $arg" >&2; exit 1 ;;
+    *) EXPLICIT="$arg" ;;
+  esac
+done
+
+# --- Guards: release from a clean, current main ---
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" != "main" ]]; then
+  echo "Error: releases are cut from main (currently on '$BRANCH')." >&2
+  exit 1
+fi
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Error: working tree is not clean. Commit or stash first." >&2
+  exit 1
+fi
+git fetch origin main --quiet
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+  echo "Error: local main is not in sync with origin/main. Pull/push first." >&2
+  exit 1
+fi
+
+CURRENT=$(bun -e "console.log(JSON.parse(require('fs').readFileSync('$PKG','utf8')).version)")
 echo "Current version: $CURRENT"
 
 # --- Determine next version ---
-if [[ $# -eq 0 ]]; then
+if [[ -z "$EXPLICIT" ]]; then
+  if [[ "$CURRENT" != *-* ]]; then
+    echo "Error: current version '$CURRENT' is stable — refusing to auto-increment." >&2
+    echo "Pass an explicit version: bin/release-beta <next>-beta.0, or <next> --stable." >&2
+    exit 1
+  fi
   # Check if current version was actually published to npm
-  if npm view "zodvex@$CURRENT" version &>/dev/null 2>&1; then
-    # Published — auto-increment as usual
+  if npm view "zodvex@$CURRENT" version &>/dev/null; then
+    # Published — bump the trailing prerelease number
     if [[ "$CURRENT" =~ ^(.+\.)([0-9]+)$ ]]; then
-      PREFIX="${BASH_REMATCH[1]}"
-      NUM="${BASH_REMATCH[2]}"
-      NEXT="${PREFIX}$((NUM + 1))"
+      NEXT="${BASH_REMATCH[1]}$((BASH_REMATCH[2] + 1))"
     else
       echo "Error: cannot auto-increment '$CURRENT'. Pass an explicit version." >&2
       exit 1
     fi
   else
-    # Not published — retry same version
+    # Not published (e.g. previous CI failure) — retry the same version
     NEXT="$CURRENT"
     echo "Version $CURRENT not found on npm — retrying release."
   fi
 else
-  NEXT="$1"
+  NEXT="$EXPLICIT"
+fi
+
+if [[ "$NEXT" != *-* && "$STABLE_FLAG" -ne 1 ]]; then
+  echo "Error: '$NEXT' is a STABLE version and would publish to npm 'latest'." >&2
+  echo "If that is intended, re-run with: bin/release-beta $NEXT --stable" >&2
+  exit 1
 fi
 
 echo "Next version:    $NEXT"
+if [[ "$NEXT" != *-* ]]; then
+  echo "*** STABLE release: publishes to npm 'latest' and creates a GitHub Release ***"
+fi
 echo ""
 
 # --- Pre-release checks ---
@@ -85,21 +135,29 @@ echo ""
 
 # --- Bump, commit, tag, push ---
 if [[ "$NEXT" != "$CURRENT" ]]; then
-  # Version changed — bump package.json and commit
-  sed -i '' "s/\"version\": \"$CURRENT\"/\"version\": \"$NEXT\"/" "$PKG"
+  # Version changed — bump package.json and commit. Edited via bun (not sed)
+  # so the same script works on macOS and Linux.
+  CURRENT="$CURRENT" NEXT="$NEXT" PKG="$PKG" bun -e "
+    const fs = require('fs')
+    const src = fs.readFileSync(process.env.PKG, 'utf8')
+    const from = '\"version\": \"' + process.env.CURRENT + '\"'
+    const to = '\"version\": \"' + process.env.NEXT + '\"'
+    if (!src.includes(from)) { console.error('version field not found'); process.exit(1) }
+    fs.writeFileSync(process.env.PKG, src.replace(from, to))
+  "
   git add "$PKG"
   git commit -m "chore: bump version to $NEXT"
 fi
 
 # Delete existing tag if present (retry after CI failure)
-if git rev-parse "v$NEXT" &>/dev/null 2>&1; then
+if git rev-parse "v$NEXT" &>/dev/null; then
   echo "Replacing existing tag v$NEXT..."
   git tag -d "v$NEXT"
   git push origin ":refs/tags/v$NEXT" 2>/dev/null || true
 fi
 
 git tag "v$NEXT"
-git push
+git push origin main
 git push origin "v$NEXT"
 
 echo ""

--- a/bin/release-beta
+++ b/bin/release-beta
@@ -37,6 +37,8 @@ for arg in "$@"; do
     *) EXPLICIT="$arg" ;;
   esac
 done
+# Tolerate a leading v ("bin/release-beta v0.8.0") — the tag adds its own.
+EXPLICIT="${EXPLICIT#v}"
 
 # --- Guards: release from a clean, current main ---
 BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/docs/releases/v0.7.7.md
+++ b/docs/releases/v0.7.7.md
@@ -1,0 +1,22 @@
+zodvex 0.7.7 clears the cross-function-call and CLI friction reported against 0.7.6. Both betas in this line were verified end-to-end by a downstream production app before this cut.
+
+## Highlights
+
+- **Convex components work from zodvex functions.** The codec-aware `ctx.runQuery`/`runMutation`/scheduler now pass non-zodvex function refs through instead of throwing `Expected a Convex function reference … received {}` — `@convex-dev/aggregate` and friends can be called directly from `zq`/`zm`/`za` handlers, including under `convex-test`. (#85)
+- **`.withContext({ args })` customization args survive cross-function calls.** Registry entries now carry the merged wire contract (authored + customization args), so forwarding an `_actor`-style arg through `ctx.runMutation` or `ctx.scheduler.runAfter` no longer strips it in flight. Re-run `zodvex generate` after upgrading so your registry picks up the merged schemas. (#88)
+- **`patch` can unset fields again.** `ctx.db.patch(id, { field: undefined })` through the secure writer deletes the field, matching native Convex semantics; `undefined` nested inside values is still stripped. **Behavior change:** partials that accidentally carried top-level `undefined` (e.g. from spreads) used to no-op those keys and now delete them — audit patch call sites that relied on the old stripping. (#82)
+- **`npx zodvex` runs on machines without Bun.** The published bin uses a Node shebang, discovery's loader hooks register under Node ESM, and both extensionless Convex-style imports and tsconfig path aliases resolve — `zodvex generate` under Node 22.18+ produces byte-identical output to the Bun run. (#89, #99)
+
+## Fixes
+
+- `toJSONSchema` handles `zx.date()` (`{ type: "string", format: "date-time" }`, same as native `z.date()`) and represents generic codecs by their wire side instead of emitting an unconstrained `{}`; user overrides run last and win. Note: the `date-time` string describes the runtime value — `zx.date()`'s wire side is epoch-ms, see the AI SDK guide. (#91)
+- `zx.date()` is detected by a runtime brand rather than shape, so user codecs with a number wire and custom runtime are no longer misidentified in `toJSONSchema` or rewritten to `zx.date()` by codegen. (#100)
+- `zodvex generate` fails loudly (non-zero exit, file list) when any module fails to import instead of silently emitting a partial registry; `ZODVEX_ALLOW_IMPORT_FAILURES=1` opts back into skip-and-continue. (#99)
+- A failed generate restores the pre-existing `_zodvex` registry instead of leaving the bootstrap stub in its place. (#104)
+- The registry-miss debug note logs once per function path per process (was: every invocation on hot paths) and no longer implies intentionally-raw call targets need codegen. (#101)
+
+## Upgrading
+
+1. `npm install zodvex@0.7.7` (or `bun add zodvex@0.7.7`)
+2. Re-run `zodvex generate` — required for the customization-args fix to take effect.
+3. Audit `patch` call sites that spread objects with possibly-`undefined` values (see behavior change above).


### PR DESCRIPTION
Release-process cleanup, all running on the repo's own credentials (`GITHUB_TOKEN` in Actions, your git credential locally).

## `bin/release-beta` hardening

The two hazards from the 0.7.7 cycle, plus guardrails:

- **No-arg mode is prerelease-only.** From a stable version (`0.7.6`), bare `bin/release-beta` used to auto-increment to `0.7.7` and publish a *stable* to npm `latest` by accident. It now errors with guidance; stables require an explicit version **and** `--stable`.
- **Portable**: `sed -i ''` (macOS-only) replaced with a bun one-liner that fails loudly if the version field doesn't match — the script now runs on Linux too.
- New guards: must be on `main`, clean working tree, in sync with `origin/main`. Pushes are explicit (`git push origin main` / `origin <tag>`).
- Unpublished-version retry and the tag-replace logic are preserved.

Verified in a sandboxed repo (local bare remote, shimmed `bun run`/`npm`): prerelease auto-increment end-to-end (bump → commit → tag on the remote), stable `--stable` end-to-end, and all four refusals (no-arg-on-stable, stable-without-flag, off-main, dirty-tree) exit 1 before any check runs.

## GitHub Releases

- **`release.yml`**: after a successful **stable** publish, creates the GitHub Release automatically — body from `docs/releases/<tag>.md` when present, GitHub's auto-generated notes appended, idempotent. Betas still get no release entry.
- **`gh-release.yml`** (new): creates a release entry for an *already-published* tag when a `gh-release/v*` branch is pushed — for retroactive entries (v0.7.7, next step) and environments whose credential can push branches but not call the releases API. It verifies the tag exists, never publishes anything, and deletes the trigger branch.
- **`docs/releases/v0.7.7.md`**: the 0.7.7 changelog, used as the release body and kept as the in-repo record.
- CLAUDE.md's Releasing section rewritten to match reality (the "no automated stable workflow" note was already stale).

## After merge

Push `gh-release/v0.7.7` → creates the GitHub Release for the stable that shipped earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxFFSVKyCRL8vjbSP41hbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxFFSVKyCRL8vjbSP41hbQ)_