### PR TITLE
chore: bump version to 0.7.8-beta.0

### DIFF
--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.7",
+  "version": "0.7.8-beta.0",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",


### PR DESCRIPTION
Version bump for the `0.7.8-beta.0` prerelease carrying #109 (db-wrap composability, #92): `initZodvex({ underlyingDb })` + `db.unwrap()`.

After merge, `release/v0.7.8-beta.0` will be pushed to trigger the tag-less release flow (release.yml verifies against package.json, creates the tag, publishes to npm `--tag beta`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQWYFjha4Gi9g9pnaArTcr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQWYFjha4Gi9g9pnaArTcr)_