### PR TITLE
feat(examples): zx.date() due dates in the task-manager frontend

### DIFF
--- a/examples/task-manager-mini/src/App.tsx
+++ b/examples/task-manager-mini/src/App.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
-import { useQuery } from 'convex/react'
 import { api } from '../convex/_generated/api'
-import { useZodMutation } from '../convex/_zodvex/client.js'
+import { useZodMutation, useZodQuery } from '../convex/_zodvex/client.js'
 import { ZodError } from 'zod'
 
 export default function App() {
@@ -63,19 +62,26 @@ function UserPanel() {
 }
 
 function TaskPanel() {
-  const tasks = useQuery(api.tasks.list, {
+  // useZodQuery (not Convex's useQuery) so the `returns` schema is decoded:
+  // `dueDate`/`createdAt` are declared as `zx.date()`, so they arrive here as
+  // real `Date` objects instead of the wire-format millisecond timestamps.
+  const tasks = useZodQuery(api.tasks.list, {
     paginationOpts: { numItems: 10, cursor: null },
   })
   const [title, setTitle] = useState('')
+  // <input type="date"> speaks 'YYYY-MM-DD'; the Date lives at the zodvex boundary.
+  const [dueDate, setDueDate] = useState('')
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [error, setError] = useState<string | null>(null)
   const createTask = useZodMutation(api.tasks.create)
   const completeTask = useZodMutation(api.tasks.complete)
 
-  // Need a user ID to create tasks — for demo, use the first user
-  // NOTE: Convex's useQuery sees runtime types for codec args (ArgsInput uses z.output).
-  // This is a known zodvex type gap — callers should ideally pass wire format { value, tag }.
-  const userByEmail = useQuery(api.users.getByEmail, {
+  // Need a user ID to create tasks — for demo, use the first user.
+  // `email` is a `tagged()` codec: runtime { value, tag, displayValue } encodes to
+  // wire { value, tag }. useZodQuery applies that encode, so we pass the runtime
+  // shape here. Convex's raw useQuery would send `displayValue` through untouched
+  // and the server's arg validator rejects it as an extra field.
+  const userByEmail = useZodQuery(api.users.getByEmail, {
     email: { value: 'demo@example.com', tag: 'email', displayValue: '[email] demo@example.com' },
   })
   const ownerId = userByEmail?._id
@@ -91,8 +97,17 @@ function TaskPanel() {
             setFieldErrors({})
             setError(null)
             try {
-              await createTask({ title, ownerId, estimate: { hours: 1, minutes: 0 } })
+              await createTask({
+                title,
+                ownerId,
+                estimate: { hours: 1, minutes: 0 },
+                // `dueDate` is `zx.date().optional()` on the server, so we hand it a
+                // real Date — useZodMutation encodes it to a timestamp on the wire.
+                // Parsed as local end-of-day so a task due today isn't instantly overdue.
+                dueDate: dueDate ? new Date(`${dueDate}T23:59:59`) : undefined,
+              })
               setTitle('')
+              setDueDate('')
             } catch (err) {
               if (err instanceof ZodError) {
                 const errors: Record<string, string> = {}
@@ -111,6 +126,13 @@ function TaskPanel() {
             <input placeholder="Task title" value={title} onChange={(e) => setTitle(e.target.value)} />
             {fieldErrors.title && <div style={{ color: 'red', fontSize: '0.8em' }}>{fieldErrors.title}</div>}
           </div>
+          <div>
+            <label>
+              Due date{' '}
+              <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} />
+            </label>
+            {fieldErrors.dueDate && <div style={{ color: 'red', fontSize: '0.8em' }}>{fieldErrors.dueDate}</div>}
+          </div>
           <button type="submit">Add Task</button>
           {error && <div style={{ color: 'red' }}>{error}</div>}
         </form>
@@ -122,7 +144,20 @@ function TaskPanel() {
         {tasks?.page?.map((task) => (
           <li key={task._id}>
             <strong>{task.title}</strong> — {task.status}
-            {task.estimate != null && ` (est: ${task.estimate} min)`}
+            {/* zDuration decodes to { hours, minutes } — the wire format is total minutes. */}
+            {task.estimate != null && ` (est: ${task.estimate.hours}h ${task.estimate.minutes}m)`}
+            {/* task.dueDate is a Date, so plain Date APIs work — no manual `new Date(ms)`. */}
+            {task.dueDate != null && (
+              <span
+                style={{
+                  marginLeft: '0.5rem',
+                  color:
+                    task.status !== 'done' && task.dueDate.getTime() < Date.now() ? 'crimson' : '#666',
+                }}
+              >
+                due {task.dueDate.toLocaleDateString()}
+              </span>
+            )}
             {task.status !== 'done' && (
               <button onClick={() => completeTask({ id: task._id })} style={{ marginLeft: '0.5rem' }}>
                 Complete

--- a/examples/task-manager/src/App.tsx
+++ b/examples/task-manager/src/App.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
-import { useQuery } from 'convex/react'
 import { api } from '../convex/_generated/api'
-import { useZodMutation } from '../convex/_zodvex/client.js'
+import { useZodMutation, useZodQuery } from '../convex/_zodvex/client.js'
 import { ZodError } from 'zod'
 
 export default function App() {
@@ -63,19 +62,26 @@ function UserPanel() {
 }
 
 function TaskPanel() {
-  const tasks = useQuery(api.tasks.list, {
+  // useZodQuery (not Convex's useQuery) so the `returns` schema is decoded:
+  // `dueDate`/`createdAt` are declared as `zx.date()`, so they arrive here as
+  // real `Date` objects instead of the wire-format millisecond timestamps.
+  const tasks = useZodQuery(api.tasks.list, {
     paginationOpts: { numItems: 10, cursor: null },
   })
   const [title, setTitle] = useState('')
+  // <input type="date"> speaks 'YYYY-MM-DD'; the Date lives at the zodvex boundary.
+  const [dueDate, setDueDate] = useState('')
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const [error, setError] = useState<string | null>(null)
   const createTask = useZodMutation(api.tasks.create)
   const completeTask = useZodMutation(api.tasks.complete)
 
-  // Need a user ID to create tasks — for demo, use the first user
-  // NOTE: Convex's useQuery sees runtime types for codec args (ArgsInput uses z.output).
-  // This is a known zodvex type gap — callers should ideally pass wire format { value, tag }.
-  const userByEmail = useQuery(api.users.getByEmail, {
+  // Need a user ID to create tasks — for demo, use the first user.
+  // `email` is a `tagged()` codec: runtime { value, tag, displayValue } encodes to
+  // wire { value, tag }. useZodQuery applies that encode, so we pass the runtime
+  // shape here. Convex's raw useQuery would send `displayValue` through untouched
+  // and the server's arg validator rejects it as an extra field.
+  const userByEmail = useZodQuery(api.users.getByEmail, {
     email: { value: 'demo@example.com', tag: 'email', displayValue: '[email] demo@example.com' },
   })
   const ownerId = userByEmail?._id
@@ -91,8 +97,17 @@ function TaskPanel() {
             setFieldErrors({})
             setError(null)
             try {
-              await createTask({ title, ownerId, estimate: { hours: 1, minutes: 0 } })
+              await createTask({
+                title,
+                ownerId,
+                estimate: { hours: 1, minutes: 0 },
+                // `dueDate` is `zx.date().optional()` on the server, so we hand it a
+                // real Date — useZodMutation encodes it to a timestamp on the wire.
+                // Parsed as local end-of-day so a task due today isn't instantly overdue.
+                dueDate: dueDate ? new Date(`${dueDate}T23:59:59`) : undefined,
+              })
               setTitle('')
+              setDueDate('')
             } catch (err) {
               if (err instanceof ZodError) {
                 const errors: Record<string, string> = {}
@@ -111,6 +126,13 @@ function TaskPanel() {
             <input placeholder="Task title" value={title} onChange={(e) => setTitle(e.target.value)} />
             {fieldErrors.title && <div style={{ color: 'red', fontSize: '0.8em' }}>{fieldErrors.title}</div>}
           </div>
+          <div>
+            <label>
+              Due date{' '}
+              <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} />
+            </label>
+            {fieldErrors.dueDate && <div style={{ color: 'red', fontSize: '0.8em' }}>{fieldErrors.dueDate}</div>}
+          </div>
           <button type="submit">Add Task</button>
           {error && <div style={{ color: 'red' }}>{error}</div>}
         </form>
@@ -122,7 +144,20 @@ function TaskPanel() {
         {tasks?.page?.map((task) => (
           <li key={task._id}>
             <strong>{task.title}</strong> — {task.status}
-            {task.estimate != null && ` (est: ${task.estimate} min)`}
+            {/* zDuration decodes to { hours, minutes } — the wire format is total minutes. */}
+            {task.estimate != null && ` (est: ${task.estimate.hours}h ${task.estimate.minutes}m)`}
+            {/* task.dueDate is a Date, so plain Date APIs work — no manual `new Date(ms)`. */}
+            {task.dueDate != null && (
+              <span
+                style={{
+                  marginLeft: '0.5rem',
+                  color:
+                    task.status !== 'done' && task.dueDate.getTime() < Date.now() ? 'crimson' : '#666',
+                }}
+              >
+                due {task.dueDate.toLocaleDateString()}
+              </span>
+            )}
             {task.status !== 'done' && (
               <button onClick={() => completeTask({ id: task._id })} style={{ marginLeft: '0.5rem' }}>
                 Complete


### PR DESCRIPTION
## Summary

Demonstrates `zx.date()` on the client, per request: the create-task form gains a due-date picker that sends a real `Date`, and the task list renders it with plain `Date` APIs (`toLocaleDateString()`, an overdue comparison) — no manual `new Date(ms)` unwrapping anywhere in component code. That's the whole point of the codec: the wire timestamp never surfaces in the UI.

Applied to both `task-manager` and `task-manager-mini`, whose `App.tsx` files were byte-identical before and still are.

## Also fixes two frontend bugs

Rendering decoded values requires `useZodQuery` instead of Convex's raw `useQuery`, which surfaced two existing problems:

1. **The app didn't render at all.** `users.getByEmail` was called through raw `useQuery` while passing the `tagged()` codec's *runtime* shape, so `displayValue` reached the server:

   ```
   ArgumentValidationError: Object contains extra field `displayValue` that is not in the validator.
   Path: .email
   Validator: v.object({tag: v.string(), value: v.string()})
   ```

   `<TaskPanel>` threw on mount. `useZodQuery` applies the codec's encode, sending only `{ value, tag }`. The stale "known zodvex type gap" comment goes with it — the hook is what closes that gap.

2. **`est: [object Object] min`.** `estimate` is a `zDuration` codec (wire: total minutes, runtime: `{ hours, minutes }`). Once decoded it's an object, so the old template string broke. Now renders `est: 1h 30m`.

Neither was catchable by typechecking — #1 is a runtime validator rejection, #2 typechecks fine as a template interpolation. Both were found by running the app.

## Test plan

Automated (all passing):

- `bun run lint`
- `bun run type-check`
- `bun run test` — 2174 passed
- `bun run build`
- `bun run verify:examples` — both example apps typecheck, test, and regenerate codegen with no drift

Manual, against real Convex dev deployments — both apps deployed and driven in a browser:

- Created the demo user, added an overdue task (8/20/2026) and a future one (12/31/2026)
- Overdue renders crimson, future renders gray
- Completing the overdue task clears the crimson and drops the button — the `status !== 'done'` guard holds
- Both form fields reset after submit
- Verified identical behavior in `task-manager-mini` (`zod/mini`), where the codec runtime path could plausibly differ

Wire-format check via the raw HTTP client confirms the encode:

```
Ship the release notes  dueDate_raw: 1787288399000  typeof: number  → Thu Aug 20 2026 23:59:59 CDT
Plan Q4 roadmap         dueDate_raw: 1798783199000  typeof: number  → Thu Dec 31 2026 23:59:59 CST
```

Stored as a `number`, calendar day preserved with no off-by-one, correct across a DST boundary (due dates are parsed as local end-of-day so a task due today isn't instantly overdue).

## Note on coverage

This verification was manual and isn't repeatable — nothing in `validate` executes `App.tsx`. `packages/zodvex/__tests__/react-hooks.test.ts` covers the `zx.date()` encode/decode logic with `convex/react` mocked, and `test/smoke.ts` hits a live deployment but via `ConvexHttpClient` in raw wire format, deliberately bypassing the codec layer. So the codec boundary has no automated coverage against a real deployment, and both bugs above could reappear silently under a refactor. Happy to add a ~20-line round-trip to `smoke.ts` (which would have caught #2 mechanically) as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)