### PR TITLE
fix(codegen): escape schema literals and property names

### DIFF
--- a/packages/zodvex/__tests__/codegen-source-escaping.test.ts
+++ b/packages/zodvex/__tests__/codegen-source-escaping.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { zodToSource } from '../src/public/codegen/zodToSource'
+
+describe('generated schema source escaping', () => {
+  it.each(['a"b', "a'b", 'a\\b', 'a\nb', '\u2028'])('round trips literal %j', value => {
+    const original = z.literal(value)
+    const generated = new Function('z', `return ${zodToSource(original)}`)(z)
+    expect(generated.parse(value)).toBe(value)
+    expect(generated.safeParse(`${value}!`).success).toBe(false)
+  })
+
+  it('round trips enum values containing quotes, slashes, and newlines', () => {
+    const values = ['a"b', 'a\\b', 'a\nb'] as const
+    const original = z.enum(values)
+    const generated = new Function('z', `return ${zodToSource(original)}`)(z)
+    for (const value of values) expect(generated.parse(value)).toBe(value)
+    expect(generated.safeParse('unknown').success).toBe(false)
+  })
+
+  it('preserves non-identifier object keys and nested values', () => {
+    const original = z.object({
+      'display-name': z.string(),
+      'a"b': z.object({ 'line\nbreak': z.literal('a"b') }),
+      '': z.boolean()
+    })
+    const generated = new Function('z', `return ${zodToSource(original)}`)(z)
+    const input = { 'display-name': 'Ada', 'a"b': { 'line\nbreak': 'a"b' }, '': true }
+    expect(generated.parse(input)).toEqual(original.parse(input))
+    expect(generated.safeParse({ ...input, 'display-name': 1 }).success).toBe(false)
+  })
+
+  it('emits __proto__ as an own shape property rather than an object prototype', () => {
+    const original = z.object({ ['__proto__']: z.string() })
+    const generated = new Function('z', `return ${zodToSource(original)}`)(z)
+    expect(Object.hasOwn(generated._zod.def.shape, '__proto__')).toBe(true)
+  })
+})

--- a/packages/zodvex/__tests__/codegen-source-escaping.test.ts
+++ b/packages/zodvex/__tests__/codegen-source-escaping.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
+import { zx } from '../src/internal/zx'
 import { zodToSource } from '../src/public/codegen/zodToSource'
 
 describe('generated schema source escaping', () => {
+  it('preserves a quoted table name in generated ID validators', () => {
+    const tableName = 'a"b'
+    const source = zodToSource(zx.id(tableName))
+    const generated = new Function('zx', `return ${source}`)(zx)
+    expect(generated._tableName).toBe(tableName)
+  })
+
   it.each(['a"b', "a'b", 'a\\b', 'a\nb', '\u2028'])('round trips literal %j', value => {
     const original = z.literal(value)
     const generated = new Function('z', `return ${zodToSource(original)}`)(z)

--- a/packages/zodvex/src/public/codegen/zodToSource.ts
+++ b/packages/zodvex/src/public/codegen/zodToSource.ts
@@ -73,7 +73,7 @@ export function zodToSource(schema: $ZodType, ctx?: ZodToSourceContext): string 
         ? (schema as any).description.slice('convexId:'.length)
         : undefined)
     if (tableName) {
-      return `zx.id("${tableName}")`
+      return `zx.id(${JSON.stringify(tableName)})`
     }
   }
 
@@ -115,7 +115,15 @@ export function zodToSource(schema: $ZodType, ctx?: ZodToSourceContext): string 
   if (schema instanceof $ZodObject) {
     const shape = schema._zod.def.shape
     const fields = Object.entries(shape)
-      .map(([key, value]) => `${key}: ${zodToSource(value, ctx)}`)
+      .map(([key, value]) => {
+        const property =
+          key === '__proto__'
+            ? `[${JSON.stringify(key)}]`
+            : /^[A-Za-z_$][\w$]*$/.test(key)
+              ? key
+              : JSON.stringify(key)
+        return `${property}: ${zodToSource(value, ctx)}`
+      })
       .join(', ')
     return `z.object({ ${fields} })`
   }
@@ -128,7 +136,7 @@ export function zodToSource(schema: $ZodType, ctx?: ZodToSourceContext): string 
   // Enums
   if (schema instanceof $ZodEnum) {
     const entries = schema._zod.def.entries
-    const values = (Object.values(entries) as string[]).map((v: string) => `"${v}"`).join(', ')
+    const values = (Object.values(entries) as string[]).map(v => JSON.stringify(v)).join(', ')
     return `z.enum([${values}])`
   }
 
@@ -136,7 +144,7 @@ export function zodToSource(schema: $ZodType, ctx?: ZodToSourceContext): string 
   if (schema instanceof $ZodLiteral) {
     const values = schema._zod.def.values
     const value = values.values().next().value
-    if (typeof value === 'string') return `z.literal("${value}")`
+    if (typeof value === 'string') return `z.literal(${JSON.stringify(value)})`
     return `z.literal(${value})`
   }
 


### PR DESCRIPTION
Generated schema source currently interpolates strings and object keys directly, so quotes, newlines, unusual enum values, and `__proto__` can produce invalid or misleading JavaScript. This change emits escaped literals and computed prototype-sensitive keys while preserving the schema's values.

Validation: focused full/mini source-generation coverage and independent code review; the combined remediation candidate passed the full local gate (2,441 tests plus typechecks, public declarations, and both example code generators). GitHub CI verifies this focused branch separately.
