### PR TITLE
fix(client): surface query errors and preserve decoded watch cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Guide: [Builders — Composing with triggers](./docs/guide/builders.md#composing
 zodvex includes an optional CLI that generates typed client code:
 
 - **Typed hooks** — `useZodQuery`, `useZodMutation`, generated into `convex/_zodvex/client` — import them from there; args are encoded and results decoded automatically
+  Invalid query arguments throw during render and can be handled by a React error boundary. Pass `'skip'` explicitly while required inputs are unavailable; encoding failures no longer silently look like a loading query.
 - **Boundary helpers** — `encodeArgs`, `decodeResult` for custom client integrations
 - **Cross-function auto-codec** — `ctx.runQuery` / `ctx.runMutation` encode args + decode results, and `ctx.scheduler.runAfter` / `ctx.scheduler.runAt` encode args, via the registry. Pass natural decoded values; zodvex encodes them to wire at the call site.
 

--- a/packages/zodvex/__tests__/react-hooks.test.ts
+++ b/packages/zodvex/__tests__/react-hooks.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
+import * as mini from 'zod/mini'
 import { stripUndefined } from '../src/internal/stripUndefined'
 import { zx } from '../src/internal/zx'
 
@@ -89,6 +90,34 @@ describe('createZodvexHooks', () => {
   // ---- useZodQuery --------------------------------------------------------
 
   describe('useZodQuery', () => {
+    it.each([
+      ['full', z],
+      ['mini', mini]
+    ] as const)('propagates even non-Error codec throws after calling the hook (%s)', (_name, schema) => {
+      const hooks = createZodvexHooks({
+        'tasks:search': {
+          args: schema.object({
+            dueAt: schema.codec(schema.number(), schema.date(), {
+              decode: value => new Date(value),
+              encode: () => {
+                throw undefined
+              }
+            })
+          })
+        }
+      })
+      let threw = false
+      try {
+        hooks.useZodQuery(fakeRef('tasks:search'), { dueAt: new Date() })
+      } catch (error) {
+        threw = true
+        expect(error).toBeUndefined()
+      }
+      expect(threw).toBe(true)
+      expect(mocks.queryArgs).toBe('skip')
+      expect(hooks.useZodQuery(fakeRef('tasks:search'), 'skip')).toBeUndefined()
+    })
+
     it('returns undefined when the query is still loading', () => {
       mocks.queryResult = undefined
       const result = useZodQuery(fakeRef('tasks:list'))
@@ -177,24 +206,14 @@ describe('createZodvexHooks', () => {
       expect(() => throwHooks.useZodQuery(fakeRef('tasks:list'))).toThrow()
     })
 
-    it('auto-skips query and logs debug when encodeArgs fails', () => {
-      // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op spy
-      const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
-      mocks.queryResult = { _id: 'x', title: 'Test', createdAt: Date.now() }
-
-      // Pass invalid args — dueAt should be a Date, passing a string triggers encode failure
-      const result = useZodQuery(fakeRef('tasks:create'), {
-        title: 'Test',
-        dueAt: 'not-a-date'
-      })
-
-      // Should auto-skip: return undefined (loading state), not throw
-      expect(result).toBeUndefined()
-      expect(debugSpy).toHaveBeenCalled()
-      const msg = debugSpy.mock.calls[0][0] as string
-      expect(msg).toContain('tasks:create')
-      expect(msg).toContain('auto-skipping')
-      debugSpy.mockRestore()
+    it('calls useQuery with skip before propagating an argument encoding failure', () => {
+      expect(() =>
+        useZodQuery(fakeRef('tasks:create'), {
+          title: 'Test',
+          dueAt: 'not-a-date'
+        })
+      ).toThrow()
+      expect(mocks.queryArgs).toBe('skip')
     })
   })
 

--- a/packages/zodvex/__tests__/zodvex-react-client.test.ts
+++ b/packages/zodvex/__tests__/zodvex-react-client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
+import * as mini from 'zod/mini'
 import { zx } from '../src/internal/zx'
 
 // ---------------------------------------------------------------------------
@@ -363,6 +364,35 @@ describe('ZodvexReactClient', () => {
   // ---- watchQuery ---------------------------------------------------------
 
   describe('watchQuery', () => {
+    it.each([
+      ['full', z],
+      ['mini', mini]
+    ] as const)('retries failed decodes without returning stale data (%s)', (_name, schema) => {
+      let wire: unknown = { createdAt: 1700000000000 }
+      mocks.watchQueryImpl = () => ({
+        onUpdate: vi.fn(),
+        localQueryResult: () => wire,
+        journal: vi.fn()
+      })
+      const strictClient = createZodvexReactClient(
+        {
+          'tasks:get': { returns: schema.object({ createdAt: zx.date() }) }
+        },
+        { url: 'https://test.convex.cloud', onDecodeError: 'throw' }
+      )
+      const watch = strictClient.watchQuery(fakeRef('tasks:get'), {})
+      const first = watch.localQueryResult()
+      expect(first.createdAt).toBeInstanceOf(Date)
+      expect(watch.localQueryResult()).toBe(first)
+      wire = { createdAt: 'invalid' }
+      expect(() => watch.localQueryResult()).toThrow()
+      expect(() => watch.localQueryResult()).toThrow()
+      wire = { createdAt: 1800000000000 }
+      expect(watch.localQueryResult().createdAt.getTime()).toBe(1800000000000)
+      wire = undefined
+      expect(watch.localQueryResult()).toBeUndefined()
+    })
+
     it('decodes localQueryResult via codec (number -> Date)', () => {
       const ts = 1700000000000
       mocks.watchQueryImpl = () => ({

--- a/packages/zodvex/src/public/react/hooks.ts
+++ b/packages/zodvex/src/public/react/hooks.ts
@@ -1,7 +1,6 @@
 import type { OptionalRestArgsOrSkip } from 'convex/react'
 import { useMutation, useQuery } from 'convex/react'
 import type { FunctionArgs, FunctionReference, FunctionReturnType } from 'convex/server'
-import { getFunctionName } from 'convex/server'
 import type { BoundaryHelpersOptions } from '../../internal/boundaryHelpers'
 import { createBoundaryHelpers } from '../../internal/boundaryHelpers'
 import type { AnyRegistry } from '../../internal/types'
@@ -45,6 +44,7 @@ export function createZodvexHooks<R extends AnyRegistry>(
    * 2. Union args (composable): `useZodQuery(ref, args | 'skip')` — for wrappers
    *    and conditional skip patterns where the decision is made upstream.
    *
+   * - Invalid arguments throw during render; use a React error boundary to handle them.
    * - Loading state (`undefined`) passes through unchanged.
    * - Functions not in the registry return the raw wire result.
    */
@@ -62,20 +62,15 @@ export function createZodvexHooks<R extends AnyRegistry>(
   function useZodQuery(ref: FunctionReference<'query', any, any, any>, ...restArgs: any[]) {
     const args = restArgs[0]
 
-    // Encode args: runtime types -> wire format (e.g., Date -> timestamp).
-    // Unlike mutations (imperative, user-triggered), hooks fire synchronously
-    // during render — an encode error would crash the page. On failure, warn
-    // and auto-skip the query (return undefined = loading state).
+    // Always call useQuery, including failed encodes, to preserve hook order.
+    // Then surface the error to React's error boundary instead of appearing to load forever.
     let wireArgs: any = 'skip'
+    let encodeFailure: { error: unknown } | undefined
     if (args !== 'skip') {
       try {
         wireArgs = codec.encodeArgs(ref, args)
-      } catch (err) {
-        const path = getFunctionName(ref)
-        console.debug(
-          `[zodvex] Encode args failed for ${path}, auto-skipping query: ${err instanceof Error ? err.message : String(err)}`
-        )
-        // wireArgs stays 'skip' — DO NOT early-return, useQuery must run every render
+      } catch (error) {
+        encodeFailure = { error }
       }
     }
 
@@ -83,6 +78,8 @@ export function createZodvexHooks<R extends AnyRegistry>(
       ref,
       ...((wireArgs === 'skip' ? ['skip'] : [wireArgs]) as OptionalRestArgsOrSkip<typeof ref>)
     )
+
+    if (encodeFailure) throw encodeFailure.error
 
     // Loading state — Convex returns undefined while the subscription is pending
     if (wireResult === undefined) return undefined

--- a/packages/zodvex/src/public/react/zodvexReactClient.ts
+++ b/packages/zodvex/src/public/react/zodvexReactClient.ts
@@ -120,8 +120,9 @@ export class ZodvexReactClient<R extends AnyRegistry = AnyRegistry> {
       localQueryResult: () => {
         const wire = innerWatch.localQueryResult()
         if (wire === lastWire) return lastDecoded
+        const decoded = wire === undefined ? undefined : this.codec.decodeResult(ref, wire)
         lastWire = wire
-        lastDecoded = wire === undefined ? undefined : this.codec.decodeResult(ref, wire)
+        lastDecoded = decoded
         return lastDecoded
       },
       journal: () => innerWatch.journal()


### PR DESCRIPTION
Invalid query arguments currently look like a query that stays loading, and a failed strict decode can poison the watch cache. The hook now preserves React hook ordering by calling the inner hook with skip, then throws the encoding error. Watches cache only successful decode results, so a failed decode can be retried without returning an earlier cached value.

This intentionally changes query argument-error behavior: invalid arguments reach React error handling instead of remaining in a loading state. Explicit skip and loading results retain their existing behavior. Experimental paginated subscriptions are unchanged.

Validation: focused full/mini client regressions and independent review passed; the combined remediation candidate passed the full local gate (2,441 tests plus compiler/declaration/example checks). GitHub CI verifies this focused branch separately.
