### PR TITLE
fix(db): preserve query expressions and close bounded scans

### DIFF
--- a/packages/zodvex/__tests__/db-query-correctness.test.ts
+++ b/packages/zodvex/__tests__/db-query-correctness.test.ts
@@ -9,6 +9,40 @@ const variants = [
   ['mini', mini.object({ score: mini.number(), enabled: mini.boolean() })]
 ] as const
 
+it('encodes codec values with serialize methods while preserving external native expressions', async () => {
+  const { filterBuilderImpl: raw } = await import(
+    '../node_modules/convex/dist/esm/server/impl/filter_builder_impl.js'
+  )
+  class Label {
+    constructor(readonly value: string) {}
+    serialize() {
+      return this.value
+    }
+  }
+  const schema = z.object({
+    label: z.codec(z.string(), z.custom<Label>(value => value instanceof Label), {
+      decode: value => new Label(value),
+      encode: value => value.value
+    }),
+    score: z.number()
+  })
+  let actual: any
+  const inner = {
+    filter(predicate: any) {
+      actual = predicate(raw)
+      return inner
+    }
+  }
+  const chain = new ZodvexQueryChain(inner, schema)
+  chain.filter((q: any) => q.eq(q.field('label'), new Label('hello')))
+  expect(actual.serialize()).toEqual({ $eq: [{ $field: 'label' }, { $literal: 'hello' }] })
+  chain.filter((q: any) => q.eq(new Label('hello'), q.field('label')))
+  expect(actual.serialize()).toEqual({ $eq: [{ $literal: 'hello' }, { $field: 'label' }] })
+  const external = raw.add(raw.field('score'), 2)
+  chain.filter((q: any) => q.eq(q.field('score'), external))
+  expect(actual.serialize()).toEqual(raw.eq(raw.field('score'), external).serialize())
+})
+
 describe.each(variants)('query correctness (%s)', (_name, schema) => {
   it('preserves arithmetic, comparison, and logical expressions on either side of comparisons', async () => {
     const { filterBuilderImpl: raw } = await import(

--- a/packages/zodvex/__tests__/db-query-correctness.test.ts
+++ b/packages/zodvex/__tests__/db-query-correctness.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import * as mini from 'zod/mini'
+import { ZodvexQueryChain } from '../src/internal/db'
+import { RulesQueryChain } from '../src/internal/rules'
+
+const variants = [
+  ['full', z.object({ score: z.number(), enabled: z.boolean() })],
+  ['mini', mini.object({ score: mini.number(), enabled: mini.boolean() })]
+] as const
+
+describe.each(variants)('query correctness (%s)', (_name, schema) => {
+  it('preserves arithmetic, comparison, and logical expressions on either side of comparisons', async () => {
+    const { filterBuilderImpl: raw } = await import(
+      '../node_modules/convex/dist/esm/server/impl/filter_builder_impl.js'
+    )
+    let actual: any
+    const inner = {
+      filter(predicate: any) {
+        actual = predicate(raw)
+        return inner
+      }
+    }
+    const chain = new ZodvexQueryChain(inner, schema)
+    const expressions = [
+      ...['add', 'sub', 'mul', 'div', 'mod'].map(op => ({
+        field: 'score',
+        build: (q: any) => q[op](q.field('score'), 2)
+      })),
+      { field: 'score', build: (q: any) => q.neg(q.field('score')) },
+      ...['eq', 'neq', 'lt', 'lte', 'gt', 'gte'].map(op => ({
+        field: 'enabled',
+        build: (q: any) => q[op](q.field('score'), 2)
+      })),
+      ...['and', 'or'].map(op => ({
+        field: 'enabled',
+        build: (q: any) => q[op](q.field('enabled'), true)
+      })),
+      { field: 'enabled', build: (q: any) => q.not(q.field('enabled')) }
+    ]
+    for (const { field, build } of expressions) {
+      for (const op of ['eq', 'neq', 'lt', 'lte', 'gt', 'gte']) {
+        for (const reverse of [false, true]) {
+          const predicate = (q: any) => {
+            const operands = [q.field(field), build(q)]
+            if (reverse) operands.reverse()
+            return q[op](...operands)
+          }
+          chain.filter(predicate)
+          expect(actual.serialize()).toEqual(predicate(raw).serialize())
+        }
+      }
+    }
+  })
+
+  function query(rule = (_ctx: unknown, doc: any) => doc.score > 0) {
+    const scanned = vi.fn()
+    const closed = vi.fn()
+    const readRule = vi.fn(rule)
+    const inner = {
+      async *[Symbol.asyncIterator]() {
+        try {
+          for (const score of [0, 1, 2]) {
+            scanned(score)
+            yield { score, enabled: true }
+          }
+        } finally {
+          closed()
+        }
+      }
+    }
+    const chain = new RulesQueryChain(inner, schema, readRule, {})
+    return { chain, scanned, closed, readRule }
+  }
+
+  it('take(0) does not start a scan or run a read rule', async () => {
+    const { chain, scanned, readRule } = query()
+    expect(await chain.take(0)).toEqual([])
+    expect(scanned).not.toHaveBeenCalled()
+    expect(readRule).not.toHaveBeenCalled()
+  })
+
+  it('take(n) stops and closes the scan immediately after n allowed documents', async () => {
+    const { chain, scanned, closed, readRule } = query()
+    expect(await chain.take(1)).toEqual([{ score: 1, enabled: true }])
+    expect(scanned.mock.calls).toEqual([[0], [1]])
+    expect(readRule).toHaveBeenCalledTimes(2)
+    expect(closed).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    -1,
+    0.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY
+  ])('rejects invalid take count %s before scanning', async count => {
+    const { chain, scanned } = query()
+    await expect(chain.take(count)).rejects.toThrow('non-negative integer')
+    expect(scanned).not.toHaveBeenCalled()
+  })
+
+  it('first closes the underlying iterator', async () => {
+    const { chain, closed } = query()
+    expect(await chain.first()).toEqual({ score: 1, enabled: true })
+    expect(closed).toHaveBeenCalledOnce()
+  })
+
+  it('breaking iteration closes the underlying iterator', async () => {
+    const { chain, closed } = query()
+    for await (const _doc of chain) break
+    expect(closed).toHaveBeenCalledOnce()
+  })
+
+  it('a throwing read rule closes the underlying iterator', async () => {
+    const failure = new Error('read denied')
+    const { chain, closed } = query(() => {
+      throw failure
+    })
+    await expect(chain.collect()).rejects.toBe(failure)
+    expect(closed).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/zodvex/__tests__/db-query-correctness.test.ts
+++ b/packages/zodvex/__tests__/db-query-correctness.test.ts
@@ -20,10 +20,14 @@ it('encodes codec values with serialize methods while preserving external native
     }
   }
   const schema = z.object({
-    label: z.codec(z.string(), z.custom<Label>(value => value instanceof Label), {
-      decode: value => new Label(value),
-      encode: value => value.value
-    }),
+    label: z.codec(
+      z.string(),
+      z.custom<Label>(value => value instanceof Label),
+      {
+        decode: value => new Label(value),
+        encode: value => value.value
+      }
+    ),
     score: z.number()
   })
   let actual: any

--- a/packages/zodvex/__tests__/db.test.ts
+++ b/packages/zodvex/__tests__/db.test.ts
@@ -841,8 +841,15 @@ describe('withSearchIndex encoding', () => {
 function createFilterCapturingMockQuery(docs: any[]) {
   const captured: { method: string; left: any; right: any }[] = []
 
+  class MockExpression {
+    constructor(private inner: any) {}
+    serialize() {
+      return this.inner
+    }
+  }
+
   function makeExpr(inner: any) {
-    return { serialize: () => inner, _isExpression: undefined }
+    return new MockExpression(inner)
   }
 
   const mockFilterBuilder: any = {

--- a/packages/zodvex/__tests__/rules.test.ts
+++ b/packages/zodvex/__tests__/rules.test.ts
@@ -646,6 +646,53 @@ describe('ZodvexDatabaseWriter.withRules()', () => {
 // ============================================================================
 
 describe('ZodvexDatabaseReader.audit()', () => {
+  function auditedScan(afterRead: ReaderAuditConfig['afterRead']) {
+    const events: string[] = []
+    const inner = createMockQuery(tableData.users)
+    inner[Symbol.asyncIterator] = async function* () {
+      try {
+        for (const doc of tableData.users) {
+          events.push(`scan:${doc._id}`)
+          yield doc
+        }
+      } finally {
+        await Promise.resolve()
+        events.push('closed')
+      }
+    }
+    const rawDb = createMockDbReader(tableData)
+    rawDb.query = () => inner
+    const db = new ZodvexDatabaseReader(rawDb, tableMap)
+    return { chain: db.audit({ afterRead }).query('users' as any), events }
+  }
+
+  it('breaking audited iteration closes the underlying iterator', async () => {
+    const audited: string[] = []
+    const { chain, events } = auditedScan((_table, doc) => {
+      audited.push(doc._id)
+    })
+    for await (const doc of chain) {
+      expect(doc.createdAt).toBeInstanceOf(Date)
+      break
+    }
+    expect(events).toEqual(['scan:users:1', 'closed'])
+    expect(audited).toEqual(['users:1'])
+  })
+
+  it('a throwing afterRead callback closes the underlying iterator', async () => {
+    const failure = new Error('audit failed')
+    const { chain, events } = auditedScan(() => {
+      throw failure
+    })
+    const consume = async () => {
+      for await (const _doc of chain) {
+        // Consume the audited iterator until it reports the callback failure.
+      }
+    }
+    await expect(consume()).rejects.toBe(failure)
+    expect(events).toEqual(['scan:users:1', 'closed'])
+  })
+
   it('afterRead fires for each doc returned by get()', async () => {
     const auditLog: any[] = []
     const db = new ZodvexDatabaseReader(createMockDbReader(tableData), tableMap)

--- a/packages/zodvex/src/internal/db.ts
+++ b/packages/zodvex/src/internal/db.ts
@@ -246,8 +246,13 @@ function wrapIndexRangeBuilder(inner: any, schema: $ZodType): any {
   })
 }
 
+function isFilterExpression(value: any): boolean {
+  // Convex expressions serialize to an AST; only literal operands need encoding.
+  return value != null && typeof value.serialize === 'function'
+}
+
 function extractFieldPath(expr: any): string | null {
-  if (expr && typeof expr.serialize === 'function') {
+  if (isFilterExpression(expr)) {
     const inner = expr.serialize()
     if (inner && typeof inner === 'object' && '$field' in inner) {
       return inner.$field
@@ -263,9 +268,9 @@ function wrapFilterBuilder(inner: any, schema: $ZodType): any {
         return (l: any, r: any) => {
           const lField = extractFieldPath(l)
           const rField = extractFieldPath(r)
-          if (lField && !rField) {
+          if (lField && !isFilterExpression(r)) {
             r = encodeIndexValue(schema, lField, r)
-          } else if (rField && !lField) {
+          } else if (rField && !isFilterExpression(l)) {
             l = encodeIndexValue(schema, rField, l)
           }
           return target[prop](l, r)

--- a/packages/zodvex/src/internal/db.ts
+++ b/packages/zodvex/src/internal/db.ts
@@ -246,13 +246,12 @@ function wrapIndexRangeBuilder(inner: any, schema: $ZodType): any {
   })
 }
 
-function isFilterExpression(value: any): boolean {
-  // Convex expressions serialize to an AST; only literal operands need encoding.
-  return value != null && typeof value.serialize === 'function'
+function isFilterExpression(value: any, expressionPrototype: object): boolean {
+  return value != null && Object.prototype.isPrototypeOf.call(expressionPrototype, value)
 }
 
-function extractFieldPath(expr: any): string | null {
-  if (isFilterExpression(expr)) {
+function extractFieldPath(expr: any, expressionPrototype: object): string | null {
+  if (isFilterExpression(expr, expressionPrototype)) {
     const inner = expr.serialize()
     if (inner && typeof inner === 'object' && '$field' in inner) {
       return inner.$field
@@ -262,15 +261,18 @@ function extractFieldPath(expr: any): string | null {
 }
 
 function wrapFilterBuilder(inner: any, schema: $ZodType): any {
+  // Use the builder's own expression type, including expressions created outside
+  // this wrapper. A codec's runtime value may also have a serialize() method.
+  const expressionPrototype = Object.getPrototypeOf(inner.field('_id'))
   return new Proxy(inner, {
     get(target, prop, receiver) {
       if (typeof prop === 'string' && ['eq', 'neq', 'lt', 'lte', 'gt', 'gte'].includes(prop)) {
         return (l: any, r: any) => {
-          const lField = extractFieldPath(l)
-          const rField = extractFieldPath(r)
-          if (lField && !isFilterExpression(r)) {
+          const lField = extractFieldPath(l, expressionPrototype)
+          const rField = extractFieldPath(r, expressionPrototype)
+          if (lField && !isFilterExpression(r, expressionPrototype)) {
             r = encodeIndexValue(schema, lField, r)
-          } else if (rField && !isFilterExpression(l)) {
+          } else if (rField && !isFilterExpression(l, expressionPrototype)) {
             l = encodeIndexValue(schema, rField, l)
           }
           return target[prop](l, r)

--- a/packages/zodvex/src/internal/rules.ts
+++ b/packages/zodvex/src/internal/rules.ts
@@ -175,10 +175,14 @@ export function installRulesSubclasses(bases: {
     }
 
     async take(n: number): Promise<Doc[]> {
+      if (!Number.isInteger(n) || n < 0) {
+        throw new Error('take requires a non-negative integer')
+      }
       const results: Doc[] = []
+      if (n === 0) return results
       for await (const doc of this as any) {
-        if (results.length >= n) break
         results.push(doc)
+        if (results.length >= n) break
       }
       return results
     }
@@ -201,10 +205,7 @@ export function installRulesSubclasses(bases: {
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<Doc> {
-      const iter = super[Symbol.asyncIterator]()
-      while (true) {
-        const { value, done } = await iter.next()
-        if (done) break
+      for await (const value of super[Symbol.asyncIterator]()) {
         const result = normalizeReadResult(await this.readRule(this.ctx, value), value)
         if (result !== null) yield result
       }

--- a/packages/zodvex/src/internal/rules.ts
+++ b/packages/zodvex/src/internal/rules.ts
@@ -513,10 +513,7 @@ export function installRulesSubclasses(bases: {
     }
 
     async *[Symbol.asyncIterator](): AsyncIterator<Doc> {
-      const iter = super[Symbol.asyncIterator]()
-      while (true) {
-        const { value, done } = await iter.next()
-        if (done) break
+      for await (const value of super[Symbol.asyncIterator]()) {
         await this.afterRead(this.tableName, value)
         yield value
       }


### PR DESCRIPTION
Wrapped filters currently try to encode arithmetic and logical Convex expressions as literal codec values. This preserves native expressions on either side of comparisons and still encodes custom codec values, including runtime classes that expose their own serialize method.

Rule-based take now scans exactly until the requested number of allowed rows, rejects invalid counts before scanning, and closes iterators on early completion or failure. take(0) does not start a scan.

Validation: 268 focused full/mini database and rule tests plus typecheck passed; the custom serialize-method regression failed before its fix. Independent code review passed. Existing comprehensive expression tests use Convex's real expression builder, including external expressions, arithmetic, comparisons, and logical expressions. GitHub CI verifies this focused branch separately.

Audit iteration also forwards cleanup on early consumer exit and afterRead failure. Four full/mini regressions failed before this correction; 168 focused tests and typecheck passed afterward, with an independent 116-test rules review pass.
