### PR TITLE
chore: unify local validation and keep deployment checks explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -23,11 +28,6 @@ jobs:
 
       - name: Validate locally (build before artifact checks)
         run: bun run validate:local
-
-      - name: Setup Node for CLI smoke test
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
 
       - name: CLI smoke test under Node (issue #89)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,27 +21,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run type check
-        run: bun run type-check
-
-      - name: Run example type checks
-        run: bun run type-check:examples
-
-      - name: Run tests
-        run: bun run test
-
-      - name: Run build
-        run: bun run build
-
-      - name: Verify example app codegen is up to date
-        run: |
-          bun install
-          bun run --cwd examples/task-manager generate
-          git diff --exit-code examples/task-manager/convex/_zodvex/ || {
-            echo ""
-            echo "ERROR: Generated files are stale. Run 'cd examples/task-manager && bun x zodvex generate' and commit the result."
-            exit 1
-          }
+      - name: Validate locally (build before artifact checks)
+        run: bun run validate:local
 
       - name: Setup Node for CLI smoke test
         uses: actions/setup-node@v4
@@ -77,21 +58,3 @@ jobs:
             echo "ERROR: failed generate clobbered the existing registry (#104)."
             exit 1
           }
-
-
-  lint:
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.9
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run lint
-        run: bun run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run type check
-        run: bun run type-check
-
-      - name: Run tests
-        run: bun run test
-
-      - name: Run lint
-        run: bun run lint
+      - name: Validate locally (build before artifact checks)
+        run: bun run validate:local
 
   release:
     needs: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,9 @@ All commands can be run from the repo root — they delegate to `packages/zodvex
 
 ### Validation
 
-- `bun run validate` - **Full pre-release validation.** Runs lint → type-check → test → verify:consumer-declarations → build → verify:examples (local) → verify:examples:network (deploys task-manager + task-manager-mini + quickstart to their Convex dev instances and runs real HTTP smoke tests) → stress-test regression gate (real deploys of the zodvex flavors at N=100 in the explicit shape — deploy parity at main's known-good level, not a ceiling search; ceilings are explored manually via `sweep`). Requires `CONVEX_DEPLOYMENT` configured in each example's `.env.local` (one-time `npx convex dev --configure` per example) plus the stress harness's own pinned deployment in `examples/stress-test/_deploy/.env.local` (see `examples/stress-test/README.md`). Run locally before trialing a release in downstream projects — CI can't do the Convex deploy step.
+- `bun run validate:local` - Lint, type-check, build, runtime and codemod correctness tests, consumer declaration checks, local examples, and generated-file freshness. Build precedes every check that consumes `dist`. CI uses this command.
+- `bun run validate:network` - Deploy example apps and run the explicit-shape N=100 stress regression. Requires configured example deployments and the stress harness's dedicated disposable deployment; the stress harness resets its target. Run after local validation.
+- `bun run validate` - Full pre-release validation: local then network validation. `bin/release-beta` uses this same pipeline. See the example and stress-test READMEs for deployment setup.
 - `bun run verify:examples` - Local-only subset (no network). Typechecks + runs vitest + regenerates codegen in both task-manager apps.
 - `bun run verify:examples:network` - Deploys schemas to real Convex and runs smoke tests. Standalone script if you want the Convex portion without the whole pipeline.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ All commands can be run from the repo root — they delegate to `packages/zodvex
 
 - `bun run validate:local` - Lint, type-check, build, runtime and codemod correctness tests, consumer declaration checks, local examples, and generated-file freshness. Build precedes every check that consumes `dist`. CI uses this command.
 - `bun run validate:network` - Deploy example apps and run the explicit-shape N=100 stress regression. Requires configured example deployments and the stress harness's dedicated disposable deployment; the stress harness resets its target. Run after local validation.
-- `bun run validate` - Full pre-release validation: local then network validation. `bin/release-beta` uses this same pipeline. See the example and stress-test READMEs for deployment setup.
+- `bun run validate` - Alias for local validation. CI and `bin/release-beta` use the same local gate. Run `validate:network` explicitly when checking deployment behavior; unavailable example deployments do not block unrelated fixes. See the example and stress-test READMEs for deployment setup.
 - `bun run verify:examples` - Local-only subset (no network). Typechecks + runs vitest + regenerates codegen in both task-manager apps.
 - `bun run verify:examples:network` - Deploys schemas to real Convex and runs smoke tests. Standalone script if you want the Convex portion without the whole pipeline.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,13 +94,18 @@ bun run lint:fix       # auto-fix
 bun run format         # format only
 ```
 
-### Full validation
+### Validation
 
-`bun run validate` runs the full pre-release pipeline: lint → type-check → test →
-verify:consumer-declarations → build → verify:examples → verify:examples:network → stress-test
-ceiling search. The network step deploys the examples to real Convex dev instances, so it
-requires a configured `CONVEX_DEPLOYMENT` per example and can't run in CI. For a local,
-no-network subset use `bun run verify:examples`.
+`bun run validate` is an alias for `bun run validate:local`, the shared CI and local
+release gate: lint → type-check → build → type-check:examples → test → test:codemod →
+verify:consumer-declarations → verify:examples → verify:generated. It needs no deployment
+credentials. The Convex-specific example typechecks run after the library build.
+
+Run `bun run validate:network` explicitly to deploy and smoke-test the examples, then
+run the N=100 explicit-shape stress regression. This requires configured example
+deployments and the stress harness's dedicated disposable deployment; see
+[the stress-test setup](examples/stress-test/README.md#setup-the-harnesss-own-deployment).
+`bun run verify:examples` is the local example-only subset and requires a library build first.
 
 ## Public API surface (current)
 
@@ -159,7 +164,8 @@ We use **vitest** (`packages/zodvex/__tests__/`), including type-level assertion
 Beta releases: `bin/release-beta` (auto-increments the prerelease number, builds, tests,
 tags, pushes). A tag push triggers `.github/workflows/release.yml` → `npm publish --tag beta`.
 Stable releases are currently cut manually. Run `bun run validate` locally before trialing a
-release downstream — CI can't perform the Convex deploy step.
+release downstream; CI uses the same local gate. Run `bun run validate:network` separately
+when checking deployment behavior against configured example deployments.
 
 ## Questions?
 

--- a/bin/release-beta
+++ b/bin/release-beta
@@ -97,41 +97,8 @@ fi
 echo ""
 
 # --- Pre-release checks ---
-echo "==> Running lint..."
-bun run lint
-echo ""
-
-echo "==> Running type-check..."
-bun run type-check
-echo ""
-
-echo "==> Running tests..."
-bun run test
-echo ""
-
-echo "==> Running build..."
-bun run build
-echo ""
-
-echo "==> Verifying consumer declaration emit..."
-bun run verify:consumer-declarations
-echo ""
-
-echo "==> Verifying example apps..."
-bun run verify:examples
-echo ""
-
-echo "==> Verifying example app codegen is up to date..."
-(cd examples/task-manager && ./node_modules/.bin/zodvex generate)
-if ! git diff --quiet examples/task-manager/convex/_zodvex/; then
-  echo ""
-  echo "ERROR: Generated files are stale. Commit regenerated output before releasing."
-  echo ""
-  git diff --stat examples/task-manager/convex/_zodvex/
-  exit 1
-fi
-echo ""
-
+echo "==> Running full validation..."
+bun run validate
 echo "All checks passed."
 echo ""
 

--- a/bin/release-beta
+++ b/bin/release-beta
@@ -97,8 +97,8 @@ fi
 echo ""
 
 # --- Pre-release checks ---
-echo "==> Running full validation..."
-bun run validate
+echo "==> Running local release validation..."
+bun run validate:local
 echo "All checks passed."
 echo ""
 

--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
       },
       "devDependencies": {
         "vite": "^8.0.3",
+        "vitest": "^4.1.0",
       },
     },
     "packages/zodvex": {

--- a/examples/stress-test/README.md
+++ b/examples/stress-test/README.md
@@ -10,7 +10,7 @@ deploy headroom" claim.
 # Build zodvex first (harness imports from built dist)
 cd ../.. && bun run build && cd examples/stress-test
 
-# Single-N regression gate (used by `bun run validate` at the repo root).
+# Single-N regression gate (used by `bun run validate:network` at the repo root).
 # Defaults: N=100 in the explicit shape — the level and shape zodvex main
 # passes. Thin-schema feature branches raise their own gate, e.g.
 # `--target=600 --shape=consolidated`.

--- a/examples/stress-test/README.md
+++ b/examples/stress-test/README.md
@@ -66,7 +66,7 @@ template.
    verify Q/M handlers actually run at runtime (catches the
    dynamic-import-unsupported regression class).
 6. **Regression** (`regression.ts`) — fixed-N pass/fail run across
-   the 5 flavors with expected outcomes. The repo-root `validate`
+   the 5 flavors with expected outcomes. The repo-root `validate:network`
    runs it for the zodvex flavors only, at `--target=100
    --shape=explicit` — a deploy-parity gate at main's known-good
    level, not a ceiling search.

--- a/examples/task-manager-mini/package.json
+++ b/examples/task-manager-mini/package.json
@@ -7,7 +7,7 @@
     "dev:once": "bunx convex dev --once",
     "build": "zodvex generate --mini && vite build",
     "deploy": "zodvex generate --mini && bunx convex deploy",
-    "generate": "zodvex generate --mini",
+    "generate": "bun ../../packages/zodvex/dist/cli/index.js generate --mini",
     "typecheck": "bunx tsc --noEmit --declaration false",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/examples/task-manager/package.json
+++ b/examples/task-manager/package.json
@@ -7,7 +7,7 @@
     "dev:once": "bunx convex dev --once",
     "build": "zodvex generate && vite build",
     "deploy": "zodvex generate && bunx convex deploy",
-    "generate": "zodvex generate",
+    "generate": "bun ../../packages/zodvex/dist/cli/index.js generate",
     "typecheck": "bunx tsc --noEmit --declaration false",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "zodvex-root",
   "private": true,
-  "workspaces": ["packages/*", "examples/*"],
+  "workspaces": [
+    "packages/*",
+    "examples/*"
+  ],
   "scripts": {
     "build": "bun run --cwd packages/zodvex build",
     "dev": "bun run --cwd packages/zodvex dev",
@@ -14,9 +17,13 @@
     "verify:consumer-declarations": "bun run --cwd packages/zodvex tsc -p ../../test-fixtures/public-declaration-smoke/tsconfig.json",
     "verify:examples": "bun run guard:mini-imports && bun run --cwd examples/stress-test typecheck && bun run --cwd examples/stress-test test && bun run --cwd examples/task-manager typecheck && bun run --cwd examples/task-manager test && bun run --cwd examples/task-manager generate && bun run --cwd examples/task-manager-mini typecheck && bun run --cwd examples/task-manager-mini test && bun run --cwd examples/task-manager-mini generate",
     "verify:examples:network": "bun run --cwd examples/task-manager dev:once && bun run --cwd examples/task-manager test:smoke && bun run --cwd examples/task-manager-mini dev:once && bun run --cwd examples/task-manager-mini test:smoke && bun run --cwd examples/quickstart dev:once && bun run --cwd examples/quickstart typecheck",
-    "validate": "bun run lint && bun run type-check && bun run test && bun run verify:consumer-declarations && bun run build && bun run verify:examples && bun run verify:examples:network && bun run --cwd examples/stress-test regression -- --target=100 --flavors=zodvex,zodvex-mini --shape=explicit",
+    "validate": "bun run validate:local && bun run validate:network",
     "type-check:examples": "bun run --cwd packages/zodvex tsc --noEmit -p ../../examples/task-manager/convex/tsconfig.json && bun run --cwd packages/zodvex tsc --noEmit -p ../../examples/task-manager-mini/convex/tsconfig.json",
-    "guard:mini-imports": "! rg -n \"zodvex/core\" examples/task-manager-mini/convex examples/task-manager-mini/src"
+    "guard:mini-imports": "! rg -n \"zodvex/core\" examples/task-manager-mini/convex examples/task-manager-mini/src",
+    "test:codemod": "bun run --cwd packages/zod-to-mini test -- src/transforms.test.ts src/vite-plugin.test.ts",
+    "verify:generated": "git diff --exit-code -- examples/task-manager/convex/_zodvex examples/task-manager-mini/convex/_zodvex",
+    "validate:local": "bun run lint && bun run type-check && bun run build && bun run test && bun run test:codemod && bun run verify:consumer-declarations && bun run verify:examples && bun run verify:generated",
+    "validate:network": "bun run verify:examples:network && bun run --cwd examples/stress-test regression -- --target=100 --flavors=zodvex,zodvex-mini --shape=explicit"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "verify:consumer-declarations": "bun run --cwd packages/zodvex tsc -p ../../test-fixtures/public-declaration-smoke/tsconfig.json",
     "verify:examples": "bun run guard:mini-imports && bun run --cwd examples/stress-test typecheck && bun run --cwd examples/stress-test test && bun run --cwd examples/task-manager typecheck && bun run --cwd examples/task-manager test && bun run --cwd examples/task-manager generate && bun run --cwd examples/task-manager-mini typecheck && bun run --cwd examples/task-manager-mini test && bun run --cwd examples/task-manager-mini generate",
     "verify:examples:network": "bun run --cwd examples/task-manager dev:once && bun run --cwd examples/task-manager test:smoke && bun run --cwd examples/task-manager-mini dev:once && bun run --cwd examples/task-manager-mini test:smoke && bun run --cwd examples/quickstart dev:once && bun run --cwd examples/quickstart typecheck",
-    "validate": "bun run validate:local && bun run validate:network",
+    "validate": "bun run validate:local",
     "type-check:examples": "bun run --cwd packages/zodvex tsc --noEmit -p ../../examples/task-manager/convex/tsconfig.json && bun run --cwd packages/zodvex tsc --noEmit -p ../../examples/task-manager-mini/convex/tsconfig.json",
     "guard:mini-imports": "! rg -n \"zodvex/core\" examples/task-manager-mini/convex examples/task-manager-mini/src",
     "test:codemod": "bun run --cwd packages/zod-to-mini test -- src/transforms.test.ts src/vite-plugin.test.ts",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "guard:mini-imports": "! rg -n \"zodvex/core\" examples/task-manager-mini/convex examples/task-manager-mini/src",
     "test:codemod": "bun run --cwd packages/zod-to-mini test -- src/transforms.test.ts src/vite-plugin.test.ts",
     "verify:generated": "git diff --exit-code -- examples/task-manager/convex/_zodvex examples/task-manager-mini/convex/_zodvex",
-    "validate:local": "bun run lint && bun run type-check && bun run build && bun run test && bun run test:codemod && bun run verify:consumer-declarations && bun run verify:examples && bun run verify:generated",
+    "validate:local": "bun run lint && bun run type-check && bun run build && bun run type-check:examples && bun run test && bun run test:codemod && bun run verify:consumer-declarations && bun run verify:examples && bun run verify:generated",
     "validate:network": "bun run verify:examples:network && bun run --cwd examples/stress-test regression -- --target=100 --flavors=zodvex,zodvex-mini --shape=explicit"
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "validate": "bun run validate:local",
     "type-check:examples": "bun run --cwd packages/zodvex tsc --noEmit -p ../../examples/task-manager/convex/tsconfig.json && bun run --cwd packages/zodvex tsc --noEmit -p ../../examples/task-manager-mini/convex/tsconfig.json",
     "guard:mini-imports": "! rg -n \"zodvex/core\" examples/task-manager-mini/convex examples/task-manager-mini/src",
-    "test:codemod": "bun run --cwd packages/zod-to-mini test -- src/transforms.test.ts src/vite-plugin.test.ts",
+    "test:codemod": "bun run --cwd packages/zod-to-mini test -- --exclude src/perf.test.ts",
     "verify:generated": "git diff --exit-code -- examples/task-manager/convex/_zodvex examples/task-manager-mini/convex/_zodvex",
     "validate:local": "bun run lint && bun run type-check && bun run build && bun run type-check:examples && bun run test && bun run test:codemod && bun run verify:consumer-declarations && bun run verify:examples && bun run verify:generated",
     "validate:network": "bun run verify:examples:network && bun run --cwd examples/stress-test regression -- --target=100 --flavors=zodvex,zodvex-mini --shape=explicit"

--- a/packages/zod-to-mini/package.json
+++ b/packages/zod-to-mini/package.json
@@ -8,12 +8,13 @@
   "types": "src/index.ts",
   "scripts": {
     "transform": "bun run src/cli.ts",
-    "test": "bunx vitest run"
+    "test": "vitest run"
   },
   "dependencies": {
     "ts-morph": "^25.0.0"
   },
   "devDependencies": {
-    "vite": "^8.0.3"
+    "vite": "^8.0.3",
+    "vitest": "^4.1.0"
   }
 }


### PR DESCRIPTION
A fresh checkout currently runs artifact-consuming checks before building, and example generation can fail until dependencies are installed a second time. CI and release preparation also use different check sequences.

This gives local development, PR CI, release CI, and local release preparation one local validation command. Build runs before declaration/tests/codegen that consume dist; internal example generation invokes the built workspace CLI directly. The codemod declares and uses its locked Vitest runner instead of letting bunx fetch another version. Existing Node CLI smoke coverage remains in PR CI.

`validate` and release preparation now run local validation. `validate:network` remains an explicit command that deploys examples and runs the destructive dedicated stress regression; failures still propagate when it is invoked. Unavailable example deployments no longer block unrelated fixes.

Validation: from a fresh isolated checkout, one `bun install --frozen-lockfile` followed by `bun run validate:local` passed: 2,344 tests, lint, typecheck, build, public declarations, both example generators, and generated freshness. Shell syntax and independent review passed. No release or deployment was invoked.
