### PR TITLE
fix(client): quarantine incompatible experimental pagination decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ zodvex includes an optional CLI that generates typed client code:
 
 - **Typed hooks** — `useZodQuery`, `useZodMutation`, generated into `convex/_zodvex/client` — import them from there; args are encoded and results decoded automatically
   Invalid query arguments throw during render and can be handled by a React error boundary. Pass `'skip'` explicitly while required inputs are unavailable; encoding failures no longer silently look like a loading query.
+- **Pagination** — use `query`, `subscribe`, or `ZodvexReactClient.watchQuery` with explicit `paginationOpts` to decode complete pages. `ZodvexClient.onPaginatedUpdate_experimental` currently throws before subscribing: Convex aggregates pages and discards the envelope required by the registered return schema. The wrapper does not yet support that aggregate contract.
 - **Boundary helpers** — `encodeArgs`, `decodeResult` for custom client integrations
 - **Cross-function auto-codec** — `ctx.runQuery` / `ctx.runMutation` encode args + decode results, and `ctx.scheduler.runAfter` / `ctx.scheduler.runAt` encode args, via the registry. Pass natural decoded values; zodvex encodes them to wire at the call site.
 

--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -182,7 +182,9 @@ function TaskDetail({ id }: { id: string }) {
 - **`ZodvexClient`** (↔ `ConvexClient`): `query`, `mutate` (alias `mutation`), `action`, `subscribe` (alias `onUpdate`), `onPaginatedUpdate_experimental`, `getAuth`, `setAuth` (accepts a token string *or* an `AuthTokenFetcher` + `onChange`), `connectionState`, `subscribeToConnectionState`, `closed` / `disabled`, `close`. The inner client is reachable via the `convex` getter.
 - **`ZodvexReactClient`** (↔ `ConvexReactClient`): `query`, `mutation`, `action`, `watchQuery`, `prewarmQuery`, `setAuth`, `clearAuth`, `connectionState`, `subscribeToConnectionState`, `url`, `logger`, `close`.
 
-The data methods (`query` / `mutate` / `action` / `subscribe` / `watchQuery` / paginated) are codec-wrapped; the auth, connection, and lifecycle methods are thin pass-throughs to the underlying Convex client.
+The data methods (`query` / `mutate` / `action` / `subscribe` / `watchQuery`) are codec-wrapped; the auth, connection, and lifecycle methods are thin pass-throughs to the underlying Convex client.
+
+`onPaginatedUpdate_experimental` is currently unavailable and throws before subscribing. Convex aggregates pages into a client result that does not preserve the page envelope required by the declared codec. Use the underlying Convex client directly when you need its experimental pagination API; that path does not apply Zodvex codecs.
 
 ## Bootstrapping note
 

--- a/packages/zodvex/__tests__/zodvex-client.test.ts
+++ b/packages/zodvex/__tests__/zodvex-client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
+import * as mini from 'zod/mini'
 import { zx } from '../src/internal/zx'
 
 // ---------------------------------------------------------------------------
@@ -421,39 +422,58 @@ describe('ZodvexClient', () => {
   // ---- onPaginatedUpdate_experimental -------------------------------------
 
   describe('onPaginatedUpdate_experimental', () => {
-    it('encodes args and decodes each page item', () => {
-      const ts = 1700000000000
-      const dueDate = new Date('2026-06-15T00:00:00Z')
-      let capturedArgs: any = null
-      let decoded: any = null
-
-      mocks.paginatedImpl = (_ref: any, args: any, _options: any, callback: any) => {
-        capturedArgs = args
-        callback({
-          page: [{ _id: 'p1', title: 'Paged', createdAt: ts }],
-          isDone: true,
-          continueCursor: ''
-        })
-        return () => {
-          /* no-op */
-        }
-      }
-
-      client.onPaginatedUpdate_experimental(
-        fakeRef('tasks:create'),
-        { title: 'x', dueAt: dueDate },
-        { initialNumItems: 10 },
-        (r: any) => {
-          decoded = r
-        }
+    it.each([
+      ['full', z],
+      ['mini', mini]
+    ] as const)('supports explicit complete-page queries (%s)', async (_name, schema) => {
+      const paginationOpts = { numItems: 10, cursor: null }
+      const wire = { page: [{ createdAt: 1700000000000 }], isDone: false, continueCursor: 'next' }
+      const query = vi.fn((_ref, args) => {
+        expect(args).toEqual({ paginationOpts })
+        return wire
+      })
+      mocks.queryImpl = query
+      const paginatedClient = createZodvexClient(
+        {
+          'tasks:page': {
+            args: schema.object({
+              paginationOpts: schema.object({
+                numItems: schema.number(),
+                cursor: schema.nullable(schema.string())
+              })
+            }),
+            returns: schema.object({
+              page: schema.array(schema.object({ createdAt: zx.date() })),
+              isDone: schema.boolean(),
+              continueCursor: schema.string()
+            })
+          }
+        },
+        { url: 'https://test.convex.cloud', onDecodeError: 'throw' }
       )
+      const result = await paginatedClient.query(fakeRef('tasks:page'), { paginationOpts })
+      expect(result.page[0].createdAt.getTime()).toBe(1700000000000)
+      expect(result.continueCursor).toBe('next')
+      expect(result.isDone).toBe(false)
+      wire.continueCursor = null as any
+      await expect(
+        paginatedClient.query(fakeRef('tasks:page'), { paginationOpts })
+      ).rejects.toThrow()
+    })
 
-      // Args encoded: Date -> number
-      expect(typeof capturedArgs.dueAt).toBe('number')
-      // Each page item decoded: number -> Date
-      expect(decoded.page[0].createdAt).toBeInstanceOf(Date)
-      expect(decoded.page[0].createdAt.getTime()).toBe(ts)
-      expect(decoded.isDone).toBe(true)
+    it('fails before creating a client or subscription with an actionable diagnostic', () => {
+      const subscribe = vi.fn()
+      mocks.paginatedImpl = subscribe
+      expect(() =>
+        client.onPaginatedUpdate_experimental(
+          fakeRef('tasks:list'),
+          {},
+          { initialNumItems: 10 },
+          vi.fn()
+        )
+      ).toThrow('Use query or subscribe with explicit paginationOpts')
+      expect(subscribe).not.toHaveBeenCalled()
+      expect(mocks.instancesCreated).toBe(0)
     })
   })
 

--- a/packages/zodvex/src/public/client/zodvexClient.ts
+++ b/packages/zodvex/src/public/client/zodvexClient.ts
@@ -128,8 +128,11 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
   }
 
   /**
-   * Experimental paginated subscription. Encodes args to wire and decodes each
-   * page item through the registry, mirroring {@link subscribe}.
+   * Currently unsupported: Convex's experimental subscription aggregates pages
+   * into `{ results, status, loadMore }`, discarding the page envelope required
+   * by the registered return schema. Throws before opening a subscription.
+   * Use {@link query} or {@link subscribe} with explicit `paginationOpts` instead.
+   * @deprecated Pending a codec-aware adapter for Convex's aggregate result contract.
    */
   onPaginatedUpdate_experimental<Q extends FunctionReference<'query', any, any, any>>(
     ref: Q,
@@ -143,19 +146,12 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
     }) => void,
     onError?: (e: Error) => void
   ): ReturnType<ConvexClient['onPaginatedUpdate_experimental']> {
-    const wireArgs = this.codec.encodeArgs(ref, args) as FunctionArgs<Q>
-    return this.getConvex().onPaginatedUpdate_experimental(
-      ref,
-      wireArgs,
-      options,
-      (wireResult: any) => {
-        callback({
-          ...wireResult,
-          page: wireResult.page.map((item: any) => this.codec.decodeResult(ref, item))
-        })
-      },
-      onError
-    ) as ReturnType<ConvexClient['onPaginatedUpdate_experimental']>
+    throw new Error(
+      '[zodvex] onPaginatedUpdate_experimental is currently unsupported: ' +
+        'Convex aggregates pages into { results, status, loadMore }, but the registry ' +
+        'validates complete pagination results. Use query or subscribe with explicit ' +
+        'paginationOpts (or ZodvexReactClient.watchQuery) to decode each complete page.'
+    )
   }
 
   /**


### PR DESCRIPTION
Quarantine the experimental pagination wrapper until its codec contract can be implemented truthfully. Convex supplies an aggregate {results, status, loadMore}, while the wrapper declares a complete PaginationResult and attempts to decode it as a page.

This deliberately makes onPaginatedUpdate_experimental throw before subscribing, with guidance to use the underlying Convex client without Zodvex codecs. Documentation explains the limitation. This is a separate draft for an API decision, not part of the ordinary correctness fixes.

Validation: Node 22 typecheck and 76 full/mini client tests passed. Independent review confirmed the installed Convex contract and pre-subscription failure; its stale guide finding is corrected.
