### PR TITLE
fix(types): expose database write and patch value contracts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
     "packages/zodvex": {
       "name": "zodvex",
-      "version": "0.7.8-beta.0",
+      "version": "0.7.8-beta.1",
       "bin": {
         "zodvex": "./dist/cli/index.js",
       },

--- a/docs/guide/custom-context.md
+++ b/docs/guide/custom-context.md
@@ -84,6 +84,38 @@ Pass either builder of the pair (`zm` or `zim`) — the result is identical and 
 
 > **Empty-args note (v0.7.4):** with `args: {}` (or no `args`), `input`'s args parameter types as `Record<string, never>`. v0.7.3 widened it to `{ [x: string]: unknown }`, which broke standalone customizations whose `input` params were hand-annotated `Record<string, never>`. v0.7.4 fixes that resolution whether or not you adopt `defineContext`.
 
+## Typing database helpers
+
+Use `ZodvexPatchValue<DataModel, DecodedDocs, TableName>` for patch arguments and
+`ZodvexWriteValue<DataModel, DecodedDocs, TableName>` for insert or replace arguments.
+Both are exported from `zodvex/server` and `zodvex/mini/server` and are the same
+types used by the database writer methods.
+
+For example, given your generated `DataModel`, decoded document map `DecodedDocs`,
+and `db: ZodvexDatabaseWriter<DataModel, DecodedDocs>`:
+
+```ts
+import type { TableNamesInDataModel } from 'convex/server'
+import type { GenericId } from 'convex/values'
+import type { ZodvexPatchValue } from 'zodvex/server'
+
+function patchTable<T extends TableNamesInDataModel<DataModel>>(
+  table: T,
+  id: GenericId<NoInfer<T>>,
+  patch: ZodvexPatchValue<DataModel, DecodedDocs, NoInfer<T>>
+) {
+  return db.patch(table, id, patch)
+}
+```
+
+`NoInfer<T>` makes the table argument determine the accepted ID and fields.
+Values use decoded types (such as `Date`) and omit `_id` and `_creationTime`.
+Object models accept partial patches; models whose decoded document type is a
+union require a complete variant to match their full encoding path. Tables absent
+from `DecodedDocs` use Convex document types and partial patches. See the
+[union patch limits](./polymorphic-tables.md) for schema unions that TypeScript
+cannot distinguish in the decoded type.
+
 ## Deprecated: `zCustomQueryBuilder` / `zCustomMutationBuilder`
 
 The standalone custom builders (`zCustomQueryBuilder`, `zCustomMutationBuilder`, `zCustomActionBuilder`) still work but are deprecated, migration-only APIs — use `.withContext()` on the `initZodvex` builders instead. See the [migration guide](../../MIGRATION.md).

--- a/docs/guide/custom-context.md
+++ b/docs/guide/custom-context.md
@@ -91,15 +91,21 @@ Use `ZodvexPatchValue<DataModel, DecodedDocs, TableName>` for patch arguments an
 Both are exported from `zodvex/server` and `zodvex/mini/server` and are the same
 types used by the database writer methods.
 
-For example, given your generated `DataModel`, decoded document map `DecodedDocs`,
-and `db: ZodvexDatabaseWriter<DataModel, DecodedDocs>`:
+For example, for an app with a `users` model created by `defineZodModel`, derive
+the decoded document map from the model's document schema:
 
 ```ts
 import type { TableNamesInDataModel } from 'convex/server'
 import type { GenericId } from 'convex/values'
-import type { ZodvexPatchValue } from 'zodvex/server'
+import type { z } from 'zod'
+import type { ZodvexDatabaseWriter, ZodvexPatchValue } from 'zodvex/server'
+import type { DataModel } from './_generated/dataModel'
+import type { users } from './models/users'
+
+type DecodedDocs = { users: z.output<typeof users.schema.doc> }
 
 function patchTable<T extends TableNamesInDataModel<DataModel>>(
+  db: ZodvexDatabaseWriter<DataModel, DecodedDocs>,
   table: T,
   id: GenericId<NoInfer<T>>,
   patch: ZodvexPatchValue<DataModel, DecodedDocs, NoInfer<T>>
@@ -109,6 +115,7 @@ function patchTable<T extends TableNamesInDataModel<DataModel>>(
 ```
 
 `NoInfer<T>` makes the table argument determine the accepted ID and fields.
+Add each modeled table to `DecodedDocs` using its own `schema.doc` output type.
 Values use decoded types (such as `Date`) and omit `_id` and `_creationTime`.
 Object models accept partial patches; models whose decoded document type is a
 union require a complete variant to match their full encoding path. Tables absent

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.8-beta.0",
+  "version": "0.7.8-beta.1",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",

--- a/packages/zodvex/src/internal/db.ts
+++ b/packages/zodvex/src/internal/db.ts
@@ -431,8 +431,8 @@ type WithoutSystemFields<Doc> = Doc extends unknown
   ? { [Key in keyof Doc as Key extends SystemFields ? never : Key]: Doc[Key] }
   : never
 
-/** Decoded doc without system fields — for insert and replace values. */
-type DecodedWriteValue<
+/** Value accepted by insert and replace: decoded document without Convex-managed fields. */
+export type ZodvexWriteValue<
   DataModel extends GenericDataModel,
   DecodedDocs extends Record<string, any>,
   TableName extends TableNamesInDataModel<DataModel>
@@ -450,12 +450,13 @@ type ModeledPatchValue<Doc> =
   true extends IsUnion<Doc> ? WithoutSystemFields<Doc> : Partial<WithoutSystemFields<Doc>>
 
 /**
+ * Value accepted by patch: partial decoded object without Convex-managed fields.
  * Union patches need a complete variant because encodePartialDoc uses full encoding.
  * Only decoded output types are available here: erased/collapsed schema unions cannot
  * be detected, and runtime encoding remains authoritative. Unmodeled tables retain
  * native partial patch values.
  */
-type DecodedPatchValue<
+export type ZodvexPatchValue<
   DataModel extends GenericDataModel,
   DecodedDocs extends Record<string, any>,
   TableName extends TableNamesInDataModel<DataModel>
@@ -660,7 +661,7 @@ export class ZodvexDatabaseWriter<
 
   insert<TableName extends TableNamesInDataModel<DataModel>>(
     table: TableName,
-    value: DecodedWriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
+    value: ZodvexWriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
   ): Promise<GenericId<TableName>>
   async insert(table: any, value: any): Promise<any> {
     const schemas = this.tableMap[table as string]
@@ -670,12 +671,12 @@ export class ZodvexDatabaseWriter<
 
   patch<TableName extends TableNamesInDataModel<DataModel>>(
     id: GenericId<TableName>,
-    value: DecodedPatchValue<DataModel, DecodedDocs, NoInfer<TableName>>
+    value: ZodvexPatchValue<DataModel, DecodedDocs, NoInfer<TableName>>
   ): Promise<void>
   patch<TableName extends TableNamesInDataModel<DataModel>>(
     table: TableName,
     id: GenericId<NoInfer<TableName>>,
-    value: DecodedPatchValue<DataModel, DecodedDocs, NoInfer<TableName>>
+    value: ZodvexPatchValue<DataModel, DecodedDocs, NoInfer<TableName>>
   ): Promise<void>
   async patch(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
     let tableName: string | null
@@ -706,12 +707,12 @@ export class ZodvexDatabaseWriter<
 
   replace<TableName extends TableNamesInDataModel<DataModel>>(
     id: GenericId<TableName>,
-    value: DecodedWriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
+    value: ZodvexWriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
   ): Promise<void>
   replace<TableName extends TableNamesInDataModel<DataModel>>(
     table: TableName,
     id: GenericId<NoInfer<TableName>>,
-    value: DecodedWriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
+    value: ZodvexWriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
   ): Promise<void>
   async replace(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
     let tableName: string | null

--- a/packages/zodvex/src/public/server/index.ts
+++ b/packages/zodvex/src/public/server/index.ts
@@ -47,8 +47,10 @@ export {
   type ZodvexIndexFieldValue,
   type ZodvexIndexRangeBuilder,
   type ZodvexLowerBoundBuilder,
+  type ZodvexPatchValue,
   ZodvexQueryChain,
-  type ZodvexUpperBoundBuilder
+  type ZodvexUpperBoundBuilder,
+  type ZodvexWriteValue
 } from '../../internal/db'
 // One-time setup + types
 export {

--- a/packages/zodvex/typechecks/database-overloads.test-d.ts
+++ b/packages/zodvex/typechecks/database-overloads.test-d.ts
@@ -132,3 +132,60 @@ indexedNotices.patch(noticeId, { kind: 'push', at: new Date() })
 indexedNotices.patch('notices', noticeId, { kind: 'email', at: new Date() })
 // @ts-expect-error Replacement fields remain required alongside an index signature.
 indexedNotices.replace(noticeId, { kind: 'push', at: new Date() })
+
+import type {
+  ZodvexPatchValue as MiniPatchValue,
+  ZodvexWriteValue as MiniWriteValue
+} from '../src/public/mini/server'
+// Generic consumers can name the writer contract without inspecting overloads.
+import type { ZodvexPatchValue, ZodvexWriteValue } from '../src/public/server'
+
+type DecodedDocs = { events: DecodedEvent }
+function patchTable<T extends keyof Model>(
+  table: T,
+  id: GenericId<NoInfer<T>>,
+  patch: ZodvexPatchValue<Model, DecodedDocs, NoInfer<T>>
+) {
+  return db.patch(table, id, patch)
+}
+function insertTable<T extends keyof Model>(
+  table: T,
+  value: ZodvexWriteValue<Model, DecodedDocs, NoInfer<T>>
+) {
+  return db.insert(table, value)
+}
+patchTable('events', eventId, { at: new Date() })
+patchTable('users', userId, { email: 'updated@example.com' })
+insertTable('events', { name: 'Launch', at: new Date() })
+// @ts-expect-error Named patch values retain decoded codec inputs.
+patchTable('events', eventId, { at: 42 })
+// @ts-expect-error The named contract does not widen table IDs.
+patchTable('events', userId, {})
+// @ts-expect-error Named write values retain required fields.
+insertTable('events', { at: new Date() })
+// @ts-expect-error System fields are not writable.
+const _systemPatch: ZodvexPatchValue<Model, DecodedDocs, 'events'> = { _creationTime: 0 }
+// @ts-expect-error Unknown tables cannot be named in the public contract.
+type _UnknownPatch = ZodvexPatchValue<Model, DecodedDocs, 'missing'>
+type _MiniPatch = Expect<
+  Equal<
+    MiniPatchValue<Model, DecodedDocs, 'events'>,
+    ZodvexPatchValue<Model, DecodedDocs, 'events'>
+  >
+>
+type _MiniWrite = Expect<
+  Equal<
+    MiniWriteValue<Model, DecodedDocs, 'events'>,
+    ZodvexWriteValue<Model, DecodedDocs, 'events'>
+  >
+>
+type _ObjectPatch = Expect<
+  Equal<ZodvexPatchValue<Model, DecodedDocs, 'events'>, { name?: string; at?: Date }>
+>
+type _NativePatch = Expect<Equal<ZodvexPatchValue<Model, DecodedDocs, 'users'>, { email?: string }>>
+type _UnionPatch = Expect<
+  Equal<
+    ZodvexPatchValue<{ notices: Table<NoticeWire> }, { notices: NoticeDoc }, 'notices'>,
+    ZodvexWriteValue<{ notices: Table<NoticeWire> }, { notices: NoticeDoc }, 'notices'>
+  >
+>

--- a/test-fixtures/public-declaration-smoke/index.ts
+++ b/test-fixtures/public-declaration-smoke/index.ts
@@ -107,3 +107,38 @@ indexedNotices.patch(noticeId, { kind: 'push', title: 'Updated', at: new Date() 
 indexedNotices.insert('notices', { kind: 'email', at: new Date() })
 // @ts-expect-error Explicit index signatures must retain required named patch fields.
 indexedNotices.patch(noticeId, { kind: 'push', at: new Date() })
+
+// Named contracts stay usable through emitted declarations and generic wrappers.
+import type { ZodvexPatchValue, ZodvexWriteValue } from 'zodvex/server'
+import type { ZodvexPatchValue as MiniPatchValue, ZodvexWriteValue as MiniWriteValue } from 'zodvex/mini/server'
+type ConsumerModel = InferDataModel<typeof FullSchema> & InferDataModel<typeof NoticeSchema>
+type ConsumerDocs = {
+  users: z.output<typeof FullUserModel.schema.doc>
+  notices: z.output<typeof NoticeModel.schema.doc>
+}
+declare const consumerDb: ZodvexDatabaseWriter<ConsumerModel, ConsumerDocs>
+export function patchConsumer<T extends keyof ConsumerModel>(
+  table: T,
+  id: GenericId<NoInfer<T>>,
+  patch: ZodvexPatchValue<ConsumerModel, ConsumerDocs, NoInfer<T>>
+) {
+  return consumerDb.patch(table, id, patch)
+}
+export function insertConsumer<T extends keyof ConsumerModel>(
+  table: T,
+  value: ZodvexWriteValue<ConsumerModel, ConsumerDocs, NoInfer<T>>
+) {
+  return consumerDb.insert(table, value)
+}
+patchConsumer('users', userId, { createdAt: new Date() })
+patchConsumer('notices', noticeId, { kind: 'push', title: 'Updated', at: new Date() })
+// @ts-expect-error Public union patch types require a complete variant.
+patchConsumer('notices', noticeId, { title: 'Updated' })
+// @ts-expect-error Public generic wrappers preserve decoded codec inputs.
+patchConsumer('users', userId, { createdAt: 42 })
+// @ts-expect-error Required fields survive through public write-value aliases.
+insertConsumer('users', { createdAt: new Date() })
+const miniPatch: MiniPatchValue<ConsumerModel, ConsumerDocs, 'users'> = { createdAt: new Date() }
+const miniWrite: MiniWriteValue<ConsumerModel, ConsumerDocs, 'users'> = { email: 'a@example.com', createdAt: new Date() }
+patchConsumer('users', userId, miniPatch)
+insertConsumer('users', miniWrite)


### PR DESCRIPTION
Generic database helpers currently have to extract insert and patch argument types from writer methods. For patch, that couples consumer code to the final overload's parameter tuple and produces conditional tuple inference just to name a patch value.

Export `ZodvexPatchValue` and `ZodvexWriteValue` from the full and mini server entrypoints, and use those aliases in the writer signatures. A consumer can now write `patch: ZodvexPatchValue<DataModel, DecodedDocs, T>`. This exposes the existing contracts without changing runtime behavior or widening accepted values. Add usage documentation and compile-time coverage for generic forwarding, decoded codec values, required union fields, native fallback, table IDs, and emitted declarations.

Prepare version 0.7.8-beta.1 so consumers can pin this candidate through the existing beta release workflow. The stable latest dist-tag remains unchanged.

Validation: `bun run validate:local` passed (2,459 tests, type checks, builds, public declarations, lint and generated-file checks). A separate local Hotpot trial used the packed candidate with Zod 4.4.3 and Convex 1.43.0, replaced overload extraction with these named types, and passed `bun run validate` (1,799 tests + 4 CLI tests; 5 existing skips; library/demo type checks and build). The Hotpot trial was not pushed. No network deployments are needed for this type-only addition.

Independent subagent review through c948f71 found no actionable issues and independently passed source type-checking and the public declaration check.
