### PR TITLE
fix(release): pin a compatible Node and npm toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,11 +121,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.22.3
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
     "packages/zodvex": {
       "name": "zodvex",
-      "version": "0.7.8-beta.1",
+      "version": "0.7.8-beta.2",
       "bin": {
         "zodvex": "./dist/cli/index.js",
       },

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.8-beta.1",
+  "version": "0.7.8-beta.2",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",


### PR DESCRIPTION
The beta.1 release failed before package build: its Node 20 publish job runs `npm install -g npm@latest`, which now selects npm 12.0.2 requiring Node ^22.22.2, ^24.15.0, or >=26. Pin the publisher to Node 22.22.3 and npm 12.0.2, matching a verified compatible pair and preventing a future npm major from silently changing the runtime requirement.

Advance the candidate to 0.7.8-beta.2 because the failed workflow already created v0.7.8-beta.1. Preserve that tag; beta.1 never reached npm publication. No library code changes.

Evidence: release run https://github.com/panzacoder/zodvex/actions/runs/34182338694 passed the full local validation job and failed with EBADENGINE in Update npm. The pinned npm CLI runs successfully under Node 22.22.3 locally. Package and workspace lock versions match.
