### PR TITLE
refactor(types): prefer concise database value names

### DIFF
--- a/docs/guide/custom-context.md
+++ b/docs/guide/custom-context.md
@@ -86,10 +86,13 @@ Pass either builder of the pair (`zm` or `zim`) — the result is identical and 
 
 ## Typing database helpers
 
-Use `ZodvexPatchValue<DataModel, DecodedDocs, TableName>` for patch arguments and
-`ZodvexWriteValue<DataModel, DecodedDocs, TableName>` for insert or replace arguments.
+Use `PatchValue<DataModel, DecodedDocs, TableName>` for patch arguments and
+`WriteValue<DataModel, DecodedDocs, TableName>` for insert or replace arguments.
 Both are exported from `zodvex/server` and `zodvex/mini/server` and are the same
 types used by the database writer methods.
+
+The earlier names `ZodvexPatchValue` and `ZodvexWriteValue` remain available as
+compatibility aliases.
 
 For example, for an app with a `users` model created by `defineZodModel`, derive
 the decoded document map from the model's document schema:
@@ -98,7 +101,7 @@ the decoded document map from the model's document schema:
 import type { TableNamesInDataModel } from 'convex/server'
 import type { GenericId } from 'convex/values'
 import type { z } from 'zod'
-import type { ZodvexDatabaseWriter, ZodvexPatchValue } from 'zodvex/server'
+import type { ZodvexDatabaseWriter, PatchValue } from 'zodvex/server'
 import type { DataModel } from './_generated/dataModel'
 import type { users } from './models/users'
 
@@ -108,7 +111,7 @@ function patchTable<T extends TableNamesInDataModel<DataModel>>(
   db: ZodvexDatabaseWriter<DataModel, DecodedDocs>,
   table: T,
   id: GenericId<NoInfer<T>>,
-  patch: ZodvexPatchValue<DataModel, DecodedDocs, NoInfer<T>>
+  patch: PatchValue<DataModel, DecodedDocs, NoInfer<T>>
 ) {
   return db.patch(table, id, patch)
 }

--- a/packages/zodvex/src/internal/db.ts
+++ b/packages/zodvex/src/internal/db.ts
@@ -432,7 +432,7 @@ type WithoutSystemFields<Doc> = Doc extends unknown
   : never
 
 /** Value accepted by insert and replace: decoded document without Convex-managed fields. */
-export type ZodvexWriteValue<
+export type WriteValue<
   DataModel extends GenericDataModel,
   DecodedDocs extends Record<string, any>,
   TableName extends TableNamesInDataModel<DataModel>
@@ -456,13 +456,16 @@ type ModeledPatchValue<Doc> =
  * be detected, and runtime encoding remains authoritative. Unmodeled tables retain
  * native partial patch values.
  */
-export type ZodvexPatchValue<
+export type PatchValue<
   DataModel extends GenericDataModel,
   DecodedDocs extends Record<string, any>,
   TableName extends TableNamesInDataModel<DataModel>
 > = TableName extends keyof DecodedDocs
   ? ModeledPatchValue<DecodedDocs[TableName]>
   : Partial<WithoutSystemFields<ResolveDecodedDoc<DataModel, DecodedDocs, TableName>>>
+
+/** Compatibility aliases for the originally published names. */
+export type { PatchValue as ZodvexPatchValue, WriteValue as ZodvexWriteValue }
 
 /**
  * Resolves a table name from a GenericId by iterating the tableMap
@@ -661,7 +664,7 @@ export class ZodvexDatabaseWriter<
 
   insert<TableName extends TableNamesInDataModel<DataModel>>(
     table: TableName,
-    value: ZodvexWriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
+    value: WriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
   ): Promise<GenericId<TableName>>
   async insert(table: any, value: any): Promise<any> {
     const schemas = this.tableMap[table as string]
@@ -671,12 +674,12 @@ export class ZodvexDatabaseWriter<
 
   patch<TableName extends TableNamesInDataModel<DataModel>>(
     id: GenericId<TableName>,
-    value: ZodvexPatchValue<DataModel, DecodedDocs, NoInfer<TableName>>
+    value: PatchValue<DataModel, DecodedDocs, NoInfer<TableName>>
   ): Promise<void>
   patch<TableName extends TableNamesInDataModel<DataModel>>(
     table: TableName,
     id: GenericId<NoInfer<TableName>>,
-    value: ZodvexPatchValue<DataModel, DecodedDocs, NoInfer<TableName>>
+    value: PatchValue<DataModel, DecodedDocs, NoInfer<TableName>>
   ): Promise<void>
   async patch(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
     let tableName: string | null
@@ -707,12 +710,12 @@ export class ZodvexDatabaseWriter<
 
   replace<TableName extends TableNamesInDataModel<DataModel>>(
     id: GenericId<TableName>,
-    value: ZodvexWriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
+    value: WriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
   ): Promise<void>
   replace<TableName extends TableNamesInDataModel<DataModel>>(
     table: TableName,
     id: GenericId<NoInfer<TableName>>,
-    value: ZodvexWriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
+    value: WriteValue<DataModel, DecodedDocs, NoInfer<TableName>>
   ): Promise<void>
   async replace(idOrTable: any, idOrValue: any, maybeValue?: any): Promise<void> {
     let tableName: string | null

--- a/packages/zodvex/src/public/server/index.ts
+++ b/packages/zodvex/src/public/server/index.ts
@@ -39,6 +39,8 @@ export {
 export {
   createZodDbReader,
   createZodDbWriter,
+  type PatchValue,
+  type WriteValue,
   ZodvexDatabaseReader,
   ZodvexDatabaseWriter,
   type ZodvexExpression,

--- a/packages/zodvex/typechecks/database-overloads.test-d.ts
+++ b/packages/zodvex/typechecks/database-overloads.test-d.ts
@@ -134,23 +134,34 @@ indexedNotices.patch('notices', noticeId, { kind: 'email', at: new Date() })
 indexedNotices.replace(noticeId, { kind: 'push', at: new Date() })
 
 import type {
-  ZodvexPatchValue as MiniPatchValue,
-  ZodvexWriteValue as MiniWriteValue
+  PatchValue as MiniPatchValue,
+  WriteValue as MiniWriteValue
 } from '../src/public/mini/server'
 // Generic consumers can name the writer contract without inspecting overloads.
-import type { ZodvexPatchValue, ZodvexWriteValue } from '../src/public/server'
+import type {
+  PatchValue,
+  WriteValue,
+  ZodvexPatchValue,
+  ZodvexWriteValue
+} from '../src/public/server'
 
 type DecodedDocs = { events: DecodedEvent }
+type _PatchAlias<T extends keyof Model> = Expect<
+  Equal<PatchValue<Model, DecodedDocs, T>, ZodvexPatchValue<Model, DecodedDocs, T>>
+>
+type _WriteAlias<T extends keyof Model> = Expect<
+  Equal<WriteValue<Model, DecodedDocs, T>, ZodvexWriteValue<Model, DecodedDocs, T>>
+>
 function patchTable<T extends keyof Model>(
   table: T,
   id: GenericId<NoInfer<T>>,
-  patch: ZodvexPatchValue<Model, DecodedDocs, NoInfer<T>>
+  patch: PatchValue<Model, DecodedDocs, NoInfer<T>>
 ) {
   return db.patch(table, id, patch)
 }
 function insertTable<T extends keyof Model>(
   table: T,
-  value: ZodvexWriteValue<Model, DecodedDocs, NoInfer<T>>
+  value: WriteValue<Model, DecodedDocs, NoInfer<T>>
 ) {
   return db.insert(table, value)
 }
@@ -164,28 +175,22 @@ patchTable('events', userId, {})
 // @ts-expect-error Named write values retain required fields.
 insertTable('events', { at: new Date() })
 // @ts-expect-error System fields are not writable.
-const _systemPatch: ZodvexPatchValue<Model, DecodedDocs, 'events'> = { _creationTime: 0 }
+const _systemPatch: PatchValue<Model, DecodedDocs, 'events'> = { _creationTime: 0 }
 // @ts-expect-error Unknown tables cannot be named in the public contract.
-type _UnknownPatch = ZodvexPatchValue<Model, DecodedDocs, 'missing'>
+type _UnknownPatch = PatchValue<Model, DecodedDocs, 'missing'>
 type _MiniPatch = Expect<
-  Equal<
-    MiniPatchValue<Model, DecodedDocs, 'events'>,
-    ZodvexPatchValue<Model, DecodedDocs, 'events'>
-  >
+  Equal<MiniPatchValue<Model, DecodedDocs, 'events'>, PatchValue<Model, DecodedDocs, 'events'>>
 >
 type _MiniWrite = Expect<
-  Equal<
-    MiniWriteValue<Model, DecodedDocs, 'events'>,
-    ZodvexWriteValue<Model, DecodedDocs, 'events'>
-  >
+  Equal<MiniWriteValue<Model, DecodedDocs, 'events'>, WriteValue<Model, DecodedDocs, 'events'>>
 >
 type _ObjectPatch = Expect<
-  Equal<ZodvexPatchValue<Model, DecodedDocs, 'events'>, { name?: string; at?: Date }>
+  Equal<PatchValue<Model, DecodedDocs, 'events'>, { name?: string; at?: Date }>
 >
-type _NativePatch = Expect<Equal<ZodvexPatchValue<Model, DecodedDocs, 'users'>, { email?: string }>>
+type _NativePatch = Expect<Equal<PatchValue<Model, DecodedDocs, 'users'>, { email?: string }>>
 type _UnionPatch = Expect<
   Equal<
-    ZodvexPatchValue<{ notices: Table<NoticeWire> }, { notices: NoticeDoc }, 'notices'>,
-    ZodvexWriteValue<{ notices: Table<NoticeWire> }, { notices: NoticeDoc }, 'notices'>
+    PatchValue<{ notices: Table<NoticeWire> }, { notices: NoticeDoc }, 'notices'>,
+    WriteValue<{ notices: Table<NoticeWire> }, { notices: NoticeDoc }, 'notices'>
   >
 >

--- a/test-fixtures/public-declaration-smoke/index.ts
+++ b/test-fixtures/public-declaration-smoke/index.ts
@@ -109,8 +109,8 @@ indexedNotices.insert('notices', { kind: 'email', at: new Date() })
 indexedNotices.patch(noticeId, { kind: 'push', at: new Date() })
 
 // Named contracts stay usable through emitted declarations and generic wrappers.
-import type { ZodvexPatchValue, ZodvexWriteValue } from 'zodvex/server'
-import type { ZodvexPatchValue as MiniPatchValue, ZodvexWriteValue as MiniWriteValue } from 'zodvex/mini/server'
+import type { PatchValue, WriteValue, ZodvexPatchValue, ZodvexWriteValue } from 'zodvex/server'
+import type { PatchValue as MiniPatchValue, WriteValue as MiniWriteValue, ZodvexPatchValue as MiniPrefixedPatchValue, ZodvexWriteValue as MiniPrefixedWriteValue } from 'zodvex/mini/server'
 type ConsumerModel = InferDataModel<typeof FullSchema> & InferDataModel<typeof NoticeSchema>
 type ConsumerDocs = {
   users: z.output<typeof FullUserModel.schema.doc>
@@ -120,13 +120,13 @@ declare const consumerDb: ZodvexDatabaseWriter<ConsumerModel, ConsumerDocs>
 export function patchConsumer<T extends keyof ConsumerModel>(
   table: T,
   id: GenericId<NoInfer<T>>,
-  patch: ZodvexPatchValue<ConsumerModel, ConsumerDocs, NoInfer<T>>
+  patch: PatchValue<ConsumerModel, ConsumerDocs, NoInfer<T>>
 ) {
   return consumerDb.patch(table, id, patch)
 }
 export function insertConsumer<T extends keyof ConsumerModel>(
   table: T,
-  value: ZodvexWriteValue<ConsumerModel, ConsumerDocs, NoInfer<T>>
+  value: WriteValue<ConsumerModel, ConsumerDocs, NoInfer<T>>
 ) {
   return consumerDb.insert(table, value)
 }
@@ -142,3 +142,15 @@ const miniPatch: MiniPatchValue<ConsumerModel, ConsumerDocs, 'users'> = { create
 const miniWrite: MiniWriteValue<ConsumerModel, ConsumerDocs, 'users'> = { email: 'a@example.com', createdAt: new Date() }
 patchConsumer('users', userId, miniPatch)
 insertConsumer('users', miniWrite)
+
+// Published prefixed names remain usable as exact compatibility aliases.
+export function prefixedConsumer<T extends keyof ConsumerModel>(
+  table: T,
+  id: GenericId<NoInfer<T>>,
+  patch: ZodvexPatchValue<ConsumerModel, ConsumerDocs, NoInfer<T>>,
+  value: ZodvexWriteValue<ConsumerModel, ConsumerDocs, NoInfer<T>>
+) {
+  const miniPatch: MiniPrefixedPatchValue<ConsumerModel, ConsumerDocs, NoInfer<T>> = patch
+  const miniWrite: MiniPrefixedWriteValue<ConsumerModel, ConsumerDocs, NoInfer<T>> = value
+  return [patchConsumer(table, id, miniPatch), insertConsumer(table, miniWrite)]
+}


### PR DESCRIPTION
Make `PatchValue` and `WriteValue` the canonical names for database helper inputs. The import from `zodvex/server` already identifies the library, so writer signatures and documentation can use the shorter contract names.

Keep `ZodvexPatchValue` and `ZodvexWriteValue` as direct compatibility aliases on the full and mini server surfaces. The underlying types and runtime behavior are unchanged. Existing generic forwarding tests now use the canonical names; additional equality and emitted-declaration checks preserve the published names, including full/mini generic forwarding.

Validation: `bun run validate:local` passed (2,459 tests plus lint, source/example types, build, public declarations, and generated-file freshness). Independent subagent review found no actionable findings and separately passed source type-checking and public declaration checks.
