### PR TITLE
chore(release): prepare 0.7.8-beta.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
     "packages/zodvex": {
       "name": "zodvex",
-      "version": "0.7.8-beta.2",
+      "version": "0.7.8-beta.3",
       "bin": {
         "zodvex": "./dist/cli/index.js",
       },

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.8-beta.2",
+  "version": "0.7.8-beta.3",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",


### PR DESCRIPTION
Prepare 0.7.8-beta.3 to publish the canonical `PatchValue` and `WriteValue` names merged in #126. The earlier prefixed exports remain compatibility aliases. Only package and workspace lock versions change; the existing release workflow publishes to the beta dist-tag and leaves stable latest unchanged.

#126 passed full local validation, independent review, and GitHub CI. This version-only change is checked by CI and the release workflow before publication.
