### PR TITLE
chore(release): prepare 0.7.9-beta.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
     "packages/zodvex": {
       "name": "zodvex",
-      "version": "0.7.8",
+      "version": "0.7.9-beta.0",
       "bin": {
         "zodvex": "./dist/cli/index.js",
       },

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.8",
+  "version": "0.7.9-beta.0",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",


### PR DESCRIPTION
Prepare 0.7.9-beta.0 for a consumer trial in Hotpot before publishing stable 0.7.9. The release contains the reviewed `useQuery_experimental` feature from #129; this PR changes only the package version.

The feature passed full local validation, CI, independent review, and actual SDK checks on Convex 1.28/1.37/1.43. The beta will be installed in an isolated Hotpot checkout for generated-client, React, and full validation checks. Hotpot !568 stays on a stable dependency until the stable release is verified.
