### PR TITLE
chore(release): prepare stable 0.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.9] - 2026-09-08
+
 ### Added
 
 - Generated clients and `createZodvexHooks` expose `useQuery_experimental`, with decoded arguments/results, explicit query states, and strict codec error handling. Calling the new hook requires Convex >=1.37; existing hooks remain compatible with older SDKs.

--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
     "packages/zodvex": {
       "name": "zodvex",
-      "version": "0.7.9-beta.0",
+      "version": "0.7.9",
       "bin": {
         "zodvex": "./dist/cli/index.js",
       },

--- a/docs/releases/v0.7.9.md
+++ b/docs/releases/v0.7.9.md
@@ -1,0 +1,20 @@
+# Zodvex 0.7.9
+
+Generated clients and `createZodvexHooks` now expose `useQuery_experimental`, matching Convex's object-form query hook while encoding arguments and decoding successful results through Zod schemas.
+
+```tsx
+const state = useQuery_experimental({ query: api.tasks.list, args: {} })
+if (state.status === 'pending') return <p>Loading…</p>
+if (state.status === 'error') return <p>{state.error.message}</p>
+return <TaskList tasks={state.data} />
+```
+
+Pass `args: 'skip'` to suspend a query. With `throwOnError: true`, failures throw and the result type contains only pending and success states. Codec failures become error states by default; native configuration errors, such as a missing provider, still throw.
+
+The new hook decodes strictly when a return schema exists. Missing schemas pass through. A custom `createZodvexHooks(registry, { onDecodeError: 'warn' })` factory explicitly retains the warning/raw-result fallback. Existing hooks keep their behavior.
+
+## Upgrade
+
+Install Zodvex 0.7.9 and rerun `zodvex generate` to add the new export to `_zodvex/client`. Calling it requires Convex >=1.37. Older SDKs can still import the generated module and use existing hooks, although bundlers may warn about the unavailable optional export; warnings-as-errors builds should also upgrade Convex.
+
+This release adds no descriptor-codegen migration or 0.8 architecture changes. Consumers upgrading from 0.7.7 should also read the 0.7.8 notes about stricter database write types.

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.9-beta.0",
+  "version": "0.7.9",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",


### PR DESCRIPTION
Prepare stable 0.7.9 with the `useQuery_experimental` feature from #129: explicit query states with Zod argument encoding and strict result decoding. Add release notes covering generated-client regeneration, Convex >=1.37 for the new hook, and unchanged legacy-hook behavior.

This promotes the same library code as 0.7.9-beta.0; only the version, lockfile, changelog, and release notes change. Full local release validation passed, including 2,290 library tests, codemod/example checks, declarations, lint, build, and generated-file freshness.

The published 0.7.9-beta.0 passed the Hotpot trial on Bun 1.3.14, Convex 1.43.0, and Zod 4.4.3: full validation (1,800 tests + 4 CLI tests, 5 existing skips), backend/demo type checks, build/codegen, and full lint. A new real React/native-hook test imports Hotpot’s generated export and verifies scope wildcard decoding to NO_CONSTRAINT, strict malformed-scope errors, skip, native query-error identity, notification-driven recovery, and subscription cleanup. Independent test review found no blocking issues. Hotpot !568 will receive the stable version only.
