### PR TITLE
feat: add codec-aware React pagination and fix vanilla subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Generated clients and `createZodvexHooks` expose `useZodPaginatedQuery`, with encoded filters and decoded accumulated items while Convex manages pagination. Aggregate pagination uses strict item decoding and rejects unsupported outer schema checks rather than silently dropping them.
+- `PaginatedResult` and `PaginatedSubscription` describe decoded vanilla pagination results and subscription controls.
+
+### Fixed
+
+- `onPaginatedUpdate_experimental` now handles Convex's actual `{ results, status, loadMore }` response instead of expecting a page envelope. Both callbacks and `getCurrentValue()` decode items; decode failures reach `onError` when supplied.
+
 ## [0.7.9] - 2026-09-08
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,10 @@
         "@biomejs/biome": "^2.2.6",
         "@types/bun": "^1.3.0",
         "@types/node": "^24.8.0",
+        "@types/react": "19.2.14",
+        "@types/react-test-renderer": "19.1.0",
         "ai": "^6.0.6",
+        "react-test-renderer": "19.2.4",
         "tsup": "^8.5.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0",
@@ -387,6 +390,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
+
     "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
@@ -603,7 +608,11 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-is": ["react-is@19.2.8", "", {}, "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ=="],
+
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "react-test-renderer": ["react-test-renderer@19.2.4", "", { "dependencies": { "react-is": "^19.2.4", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-Ttl5D7Rnmi6JGMUpri4UjB4BAN0FPs4yRDnu2XSsigCWOLm11o8GwRlVsh27ER+4WFqsGtrBuuv5zumUaRCmKw=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
     "packages/zodvex": {
       "name": "zodvex",
-      "version": "0.7.9",
+      "version": "0.7.10-beta.0",
       "bin": {
         "zodvex": "./dist/cli/index.js",
       },

--- a/docs/decisions/2026-09-07-boundary-contract.md
+++ b/docs/decisions/2026-09-07-boundary-contract.md
@@ -41,13 +41,23 @@ Audit callbacks are awaited after their corresponding inner operation. Compositi
 
 `unwrap()` deliberately returns the native database handle and bypasses codecs, rules and audit. `wrapDb: false` also opts out of database wrapping. Neither is evidence that the wrapped path preserves fewer guarantees. Tests: [rules/audit composition](../../packages/zodvex/__tests__/rules.test.ts), [underlying database](../../packages/zodvex/__tests__/underlying-db.test.ts), [initialization](../../packages/zodvex/__tests__/init.test.ts).
 
-## Separate experimental pagination limitation
+## Aggregate pagination
 
-The installed Convex 1.32.0 experimental client subscription dispatches aggregate `{ results, status, loadMore }` values, despite its callback type declaring a pagination envelope. The previous zodvex wrapper expected `.page` and attempted to decode each item with the complete function return schema. That is not a supported codec contract.
+`useZodPaginatedQuery` and `onPaginatedUpdate_experimental` delegate pagination to Convex
+and decode accumulated items using the registered return object's `page` array schema.
+They encode domain arguments using the argument object with `paginationOpts` omitted.
+No synthetic page envelope is constructed. Both the vanilla callback and the subscription's
+current-value reader decode results.
 
-The separate remediation makes `onPaginatedUpdate_experimental` fail before subscribing with an actionable diagnostic. Supported alternatives are `query`, `subscribe`, or `ZodvexReactClient.watchQuery` with explicit `paginationOpts`, which retain the complete return envelope. A future aggregate adapter must define argument encoding, item decoding, outer-schema limitations and current-value access; it must not fabricate cursors to claim complete-page validation.
+This intentionally has an item-level contract: complete return-envelope checks cannot run
+after Convex discards page metadata. Outer argument/return refinements and transforms and
+page-array checks or transforms are rejected rather than silently dropped. Item schemas
+retain their normal decoding behavior. Missing schemas pass through. Codec failures throw,
+independently of the warn-mode policy on existing ordinary query methods.
 
-Implementation and tests: [client](../../packages/zodvex/src/public/client/zodvexClient.ts), [client regressions](../../packages/zodvex/__tests__/zodvex-client.test.ts). Apply the restriction only with its separate implementation change; this document alone does not change the API.
+For complete-page parsing use `query`, `subscribe`, or `watchQuery` with explicit
+`paginationOpts`. Convex 1.45.0 still dispatches aggregate vanilla callbacks despite its
+page-envelope callback declaration; the wrapper isolates that mismatch at the SDK boundary.
 
 ## Evidence and next decision gate
 

--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -242,6 +242,8 @@ Its callback receives `{ results, status, loadMore }`, matching Convex's runtime
 its returned subscription decodes `getCurrentValue()` too. Call the subscription itself
 or `.unsubscribe()` to stop it. `.getQueryLogs()` returns `undefined` on SDK versions
 without that method. This corrects the previous, non-working page-envelope signature.
+Provide `onError` when sharing a vanilla client across subscriptions: without it, a decode
+failure throws from Convex's callback loop and can interrupt sibling callbacks in that update.
 
 ## Bootstrapping note
 

--- a/docs/guide/codegen.md
+++ b/docs/guide/codegen.md
@@ -206,6 +206,43 @@ By default, argument encoding and result decoding failures become an `error` sta
 
 The data methods (`query` / `mutate` / `action` / `subscribe` / `watchQuery` / paginated) are codec-wrapped; the auth, connection, and lifecycle methods are thin pass-throughs to the underlying Convex client.
 
+### Paginated React queries
+
+Generated clients export `useZodPaginatedQuery`:
+
+```tsx
+import { useZodPaginatedQuery } from '../convex/_zodvex/client'
+
+const { results, status, isLoading, loadMore } = useZodPaginatedQuery(
+  api.tasks.list,
+  { after: new Date() },
+  { initialNumItems: 25 }
+)
+```
+
+Pass domain arguments or `'skip'`; Convex supplies `paginationOpts`, manages live pages,
+page splits and cursors, and accumulates results. Zodvex encodes the domain arguments
+and decodes result items using the registered `returns.page` array schema.
+
+This requires an ordinary argument object and an ordinary return object containing
+`page: z.array(itemSchema)`. Argument-object refinements, return-object refinements or
+transforms, and page-array refinements or transforms are rejected. Item schemas retain
+codecs, refinements, unions, defaults and transforms supported by normal Zod decoding.
+Functions without a relevant registry schema pass through unchanged.
+
+These aggregate APIs validate items, not the original page envelopes or their metadata.
+They do not fabricate a cursor or a page completion flag to run the return schema.
+Use `query`, `subscribe`, or `watchQuery` with explicit `paginationOpts` when you need
+client-side validation of complete pages. Codec failures always throw, even when the
+factory uses `onDecodeError: 'warn'` for its other methods. Handle React failures with
+an error boundary; invalid arguments do not start a subscription.
+
+`ZodvexClient.onPaginatedUpdate_experimental` uses the same argument and item contract.
+Its callback receives `{ results, status, loadMore }`, matching Convex's runtime, and
+its returned subscription decodes `getCurrentValue()` too. Call the subscription itself
+or `.unsubscribe()` to stop it. `.getQueryLogs()` returns `undefined` on SDK versions
+without that method. This corrects the previous, non-working page-envelope signature.
+
 ## Bootstrapping note
 
 The first time you run `zodvex generate`, your `functions.ts` likely already imports from `_zodvex/api.js` (to wire the registry). The CLI handles this chicken-and-egg problem by writing a minimal stub `api.js` before discovery runs, then overwriting it with the real generated output.

--- a/examples/task-manager-mini/convex/_zodvex/client.d.ts
+++ b/examples/task-manager-mini/convex/_zodvex/client.d.ts
@@ -7,6 +7,7 @@ import type { ZodvexReactClientOptions, ZodvexReactClient } from 'zodvex/react'
 import type { BoundaryHelpers } from 'zodvex/mini'
 
 export declare const useZodQuery: ZodvexHooks['useZodQuery']
+export declare const useZodPaginatedQuery: ZodvexHooks['useZodPaginatedQuery']
 export declare const useQuery_experimental: ZodvexHooks['useQuery_experimental']
 export declare const useZodMutation: ZodvexHooks['useZodMutation']
 

--- a/examples/task-manager-mini/convex/_zodvex/client.js
+++ b/examples/task-manager-mini/convex/_zodvex/client.js
@@ -7,7 +7,7 @@ import { createZodvexClient } from 'zodvex/client'
 import { createBoundaryHelpers } from 'zodvex/mini'
 import { zodvexRegistry } from './api.js'
 
-export const { useZodQuery, useZodMutation, useQuery_experimental } = createZodvexHooks(zodvexRegistry)
+export const { useZodQuery, useZodMutation, useZodPaginatedQuery, useQuery_experimental } = createZodvexHooks(zodvexRegistry)
 
 export const createClient = (options) =>
   createZodvexClient(zodvexRegistry, options)

--- a/examples/task-manager/convex/_zodvex/client.d.ts
+++ b/examples/task-manager/convex/_zodvex/client.d.ts
@@ -7,6 +7,7 @@ import type { ZodvexReactClientOptions, ZodvexReactClient } from 'zodvex/react'
 import type { BoundaryHelpers } from 'zodvex'
 
 export declare const useZodQuery: ZodvexHooks['useZodQuery']
+export declare const useZodPaginatedQuery: ZodvexHooks['useZodPaginatedQuery']
 export declare const useQuery_experimental: ZodvexHooks['useQuery_experimental']
 export declare const useZodMutation: ZodvexHooks['useZodMutation']
 

--- a/examples/task-manager/convex/_zodvex/client.js
+++ b/examples/task-manager/convex/_zodvex/client.js
@@ -7,7 +7,7 @@ import { createZodvexClient } from 'zodvex/client'
 import { createBoundaryHelpers } from 'zodvex'
 import { zodvexRegistry } from './api.js'
 
-export const { useZodQuery, useZodMutation, useQuery_experimental } = createZodvexHooks(zodvexRegistry)
+export const { useZodQuery, useZodMutation, useZodPaginatedQuery, useQuery_experimental } = createZodvexHooks(zodvexRegistry)
 
 export const createClient = (options) =>
   createZodvexClient(zodvexRegistry, options)

--- a/packages/zodvex/__tests__/cli-init.test.ts
+++ b/packages/zodvex/__tests__/cli-init.test.ts
@@ -34,6 +34,7 @@ describe('generateStubs', () => {
     expect(content).toContain('useZodQuery')
     expect(content).toContain('useZodMutation')
     expect(content).toContain('useQuery_experimental')
+    expect(content).toContain('useZodPaginatedQuery')
     expect(content).toContain('createClient')
   })
 

--- a/packages/zodvex/__tests__/codegen-generate.test.ts
+++ b/packages/zodvex/__tests__/codegen-generate.test.ts
@@ -267,7 +267,7 @@ describe('generateClientFile', () => {
     expect(js).toContain("import { createBoundaryHelpers } from 'zodvex'")
     expect(js).toContain("import { zodvexRegistry } from './api.js'")
     expect(js).toContain(
-      'export const { useZodQuery, useZodMutation, useQuery_experimental } = createZodvexHooks(zodvexRegistry)'
+      'export const { useZodQuery, useZodMutation, useZodPaginatedQuery, useQuery_experimental } = createZodvexHooks(zodvexRegistry)'
     )
     expect(js).toContain('export const createClient = (options) =>')
     expect(js).toContain('export const createReactClient = (options) =>')
@@ -284,6 +284,9 @@ describe('generateClientFile', () => {
     expect(dts).toContain("export declare const useZodQuery: ZodvexHooks['useZodQuery']")
     expect(dts).toContain(
       "export declare const useQuery_experimental: ZodvexHooks['useQuery_experimental']"
+    )
+    expect(dts).toContain(
+      "export declare const useZodPaginatedQuery: ZodvexHooks['useZodPaginatedQuery']"
     )
     expect(dts).toContain("export declare const useZodMutation: ZodvexHooks['useZodMutation']")
     expect(dts).toContain('export declare const createClient:')

--- a/packages/zodvex/__tests__/pagination-codec.test.ts
+++ b/packages/zodvex/__tests__/pagination-codec.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { createPaginationCodec } from '../src/internal/paginationCodec'
+import { zx } from '../src/internal/zx'
+
+const ref = { [Symbol.for('functionName')]: 'tasks:list' } as any
+const args = z.object({
+  after: zx.date(),
+  paginationOpts: z.object({ cursor: z.string().nullable(), numItems: z.number() })
+})
+const returns = z.object({
+  page: z.array(z.object({ at: zx.date() })),
+  isDone: z.boolean(),
+  continueCursor: z.string()
+})
+
+describe('pagination codec', () => {
+  it('encodes filters without requiring or fabricating paginationOpts', () => {
+    const codec = createPaginationCodec({ 'tasks:list': { args, returns } })
+    expect(codec.encodeArgs(ref, { after: new Date(123) })).toEqual({ after: 123 })
+    expect(() => codec.encodeArgs(ref, { after: 'invalid' })).toThrow()
+  })
+  it('decodes items and preserves item refinements', () => {
+    const codec = createPaginationCodec({ 'tasks:list': { args, returns } })
+    expect(codec.decodeResults(ref, [{ at: 123 }])).toEqual([{ at: new Date(123) }])
+    expect(() => codec.decodeResults(ref, [{ at: 'invalid' }])).toThrow()
+  })
+  it('passes through functions without schemas', () => {
+    const codec = createPaginationCodec({})
+    const items = [{ at: 123 }]
+    expect(codec.decodeResults(ref, items)).toBe(items)
+    expect(codec.encodeArgs(ref, { limit: 1 })).toEqual({ limit: 1 })
+  })
+  it('rejects outer refinements even for an empty result', () => {
+    const codec = createPaginationCodec({
+      'tasks:list': { returns: returns.refine(v => v.isDone) }
+    })
+    expect(() => codec.decodeResults(ref, [])).toThrow(/pagination.*schema/i)
+  })
+  it('rejects per-page array checks instead of applying them to accumulated results', () => {
+    const codec = createPaginationCodec({
+      'tasks:list': { returns: z.object({ page: z.array(z.string()).max(10) }) }
+    })
+    expect(() => codec.decodeResults(ref, [])).toThrow(/pagination.*schema/i)
+  })
+  it('rejects argument object refinements rather than silently stripping them', () => {
+    const codec = createPaginationCodec({
+      'tasks:list': { args: args.refine(v => v.paginationOpts.numItems < 10) }
+    })
+    expect(() => codec.encodeArgs(ref, { after: new Date(123) })).toThrow(/pagination.*schema/i)
+  })
+  it('enforces refinements inside each item', () => {
+    const codec = createPaginationCodec({
+      'tasks:list': {
+        returns: z.object({
+          page: z.array(z.object({ at: zx.date() }).refine(item => item.at.getTime() > 100))
+        })
+      }
+    })
+    expect(codec.decodeResults(ref, [{ at: 123 }])).toEqual([{ at: new Date(123) }])
+    expect(() => codec.decodeResults(ref, [{ at: 1 }])).toThrow()
+  })
+  it('rejects outer transforms instead of losing their behavior', () => {
+    const codec = createPaginationCodec({
+      'tasks:list': { returns: returns.transform(value => value) }
+    })
+    expect(() => codec.decodeResults(ref, [])).toThrow(/pagination.*schema/i)
+  })
+})

--- a/packages/zodvex/__tests__/react-pagination.test.ts
+++ b/packages/zodvex/__tests__/react-pagination.test.ts
@@ -1,0 +1,158 @@
+import { ConvexProvider, type ConvexReactClient } from 'convex/react'
+import { anyApi, makeFunctionReference } from 'convex/server'
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { zx } from '../src/internal/zx'
+import { createZodvexHooks } from '../src/public/react/hooks'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+const ref = makeFunctionReference<
+  'query',
+  { after: Date; paginationOpts: { numItems: number; cursor: string | null } },
+  { page: { at: Date }[]; isDone: boolean; continueCursor: string }
+>('tasks:list')
+const hooks = createZodvexHooks({
+  'tasks:list': {
+    args: z.object({
+      after: zx.date(),
+      paginationOpts: z.object({ numItems: z.number(), cursor: z.string().nullable() })
+    }),
+    returns: z.object({
+      page: z.array(z.object({ at: zx.date() })),
+      isDone: z.boolean(),
+      continueCursor: z.string()
+    })
+  }
+})
+let root: ReactTestRenderer | undefined
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  root = undefined
+})
+
+describe('useZodPaginatedQuery with the real Convex hook', () => {
+  it('encodes filters, loads successive pages, handles skip and preserves decoded identity', async () => {
+    const seen: any[] = []
+    const pages = new Map<string | null, unknown>([
+      [null, { page: [{ at: 123 }], isDone: false, continueCursor: 'next' }],
+      ['next', { page: [{ at: 456 }], isDone: true, continueCursor: 'end' }]
+    ])
+    const listeners = new Set<() => void>()
+    const client = {
+      watchQuery(_ref: unknown, args: any) {
+        seen.push(args)
+        return {
+          localQueryResult: () => pages.get(args.paginationOpts.cursor),
+          journal: () => undefined,
+          onUpdate(fn: () => void) {
+            listeners.add(fn)
+            return () => {
+              listeners.delete(fn)
+            }
+          }
+        }
+      }
+    } as unknown as ConvexReactClient
+    let state: any
+    function View({ skip = false }) {
+      state = hooks.useZodPaginatedQuery(
+        anyApi.tasks.list as typeof ref,
+        skip ? 'skip' : { after: new Date(10) },
+        { initialNumItems: 1 }
+      )
+      return null
+    }
+    const view = (skip = false) =>
+      createElement(ConvexProvider, { client }, createElement(View, { skip }))
+    await act(async () => {
+      root = create(view())
+    })
+    expect(state.results).toEqual([{ at: new Date(123) }])
+    expect(state.status).toBe('CanLoadMore')
+    expect(seen[0]).toMatchObject({ after: 10, paginationOpts: { cursor: null, numItems: 1 } })
+    const first = state.results
+    await act(async () => root!.update(view()))
+    expect(state.results).toBe(first)
+    await act(async () => state.loadMore(1))
+    expect(state.results).toEqual([{ at: new Date(123) }, { at: new Date(456) }])
+    expect(state.status).toBe('Exhausted')
+    expect(seen.some(args => args.paginationOpts.cursor === 'next')).toBe(true)
+    await act(async () => root!.update(view(true)))
+    expect(state.results).toEqual([])
+    expect(listeners.size).toBe(0)
+    await act(async () => root!.update(view()))
+    expect(state.results).toEqual([{ at: new Date(123) }])
+  })
+  it('reports loading and live updates from actual watches', async () => {
+    let wire: unknown
+    const listeners = new Set<() => void>()
+    const client = {
+      watchQuery() {
+        return {
+          localQueryResult: () => wire,
+          journal: () => undefined,
+          onUpdate(fn: () => void) {
+            listeners.add(fn)
+            return () => {
+              listeners.delete(fn)
+            }
+          }
+        }
+      }
+    } as unknown as ConvexReactClient
+    let state: any
+    function View() {
+      state = hooks.useZodPaginatedQuery(ref, { after: new Date(10) }, { initialNumItems: 1 })
+      return null
+    }
+    await act(async () => {
+      root = create(createElement(ConvexProvider, { client }, createElement(View)))
+    })
+    expect(state.status).toBe('LoadingFirstPage')
+    expect(state.results).toEqual([])
+    wire = { page: [{ at: 123 }], isDone: true, continueCursor: 'end' }
+    await act(async () => {
+      for (const notify of listeners) notify()
+    })
+    expect(state.results).toEqual([{ at: new Date(123) }])
+    wire = { page: [{ at: 456 }], isDone: true, continueCursor: 'end' }
+    await act(async () => {
+      for (const notify of listeners) notify()
+    })
+    expect(state.results).toEqual([{ at: new Date(456) }])
+  })
+
+  it.each(['encode', 'decode', 'server'] as const)('surfaces %s failures', async kind => {
+    let subscriptions = 0
+    const client = {
+      watchQuery() {
+        subscriptions++
+        return {
+          localQueryResult() {
+            if (kind === 'server') throw new Error('server failure')
+            return { page: [{ at: 'invalid' }], isDone: true, continueCursor: 'end' }
+          },
+          journal: () => undefined,
+          onUpdate: () => () => undefined
+        }
+      }
+    } as unknown as ConvexReactClient
+    function View() {
+      hooks.useZodPaginatedQuery(
+        ref,
+        { after: kind === 'encode' ? ('invalid' as any) : new Date(10) },
+        { initialNumItems: 1 }
+      )
+      return null
+    }
+    await expect(
+      act(async () => {
+        root = create(createElement(ConvexProvider, { client }, createElement(View)))
+      })
+    ).rejects.toThrow()
+    if (kind === 'encode') expect(subscriptions).toBe(0)
+  })
+})

--- a/packages/zodvex/__tests__/zodvex-client.test.ts
+++ b/packages/zodvex/__tests__/zodvex-client.test.ts
@@ -421,40 +421,122 @@ describe('ZodvexClient', () => {
   // ---- onPaginatedUpdate_experimental -------------------------------------
 
   describe('onPaginatedUpdate_experimental', () => {
-    it('encodes args and decodes each page item', () => {
-      const ts = 1700000000000
-      const dueDate = new Date('2026-06-15T00:00:00Z')
-      let capturedArgs: any = null
-      let decoded: any = null
-
-      mocks.paginatedImpl = (_ref: any, args: any, _options: any, callback: any) => {
-        capturedArgs = args
-        callback({
-          page: [{ _id: 'p1', title: 'Paged', createdAt: ts }],
-          isDone: true,
-          continueCursor: ''
-        })
-        return () => {
-          /* no-op */
-        }
+    it('decodes aggregate callbacks and current values while preserving controls', () => {
+      const ref = fakeRef('tasks:page')
+      const loadMore = vi.fn(() => true)
+      const stop = vi.fn()
+      let wire: any = { results: [{ createdAt: 123 }], status: 'CanLoadMore', loadMore }
+      const native = Object.assign(stop, {
+        unsubscribe: stop,
+        getCurrentValue: () => wire,
+        getQueryLogs: () => ['query log']
+      })
+      const callback = vi.fn()
+      mocks.paginatedImpl = (_ref, args, options, onResult) => {
+        expect(args).toEqual({ after: 123 })
+        expect(options).toEqual({ initialNumItems: 10 })
+        onResult(wire)
+        return native
       }
-
-      client.onPaginatedUpdate_experimental(
-        fakeRef('tasks:create'),
-        { title: 'x', dueAt: dueDate },
-        { initialNumItems: 10 },
-        (r: any) => {
-          decoded = r
-        }
+      const client = createZodvexClient(
+        {
+          'tasks:page': {
+            args: z.object({
+              after: zx.date(),
+              paginationOpts: z.object({ cursor: z.string().nullable(), numItems: z.number() })
+            }),
+            returns: z.object({
+              page: z.array(z.object({ createdAt: zx.date() })),
+              isDone: z.boolean(),
+              continueCursor: z.string()
+            })
+          }
+        },
+        { url: 'https://test.convex.cloud' }
       )
-
-      // Args encoded: Date -> number
-      expect(typeof capturedArgs.dueAt).toBe('number')
-      // Each page item decoded: number -> Date
-      expect(decoded.page[0].createdAt).toBeInstanceOf(Date)
-      expect(decoded.page[0].createdAt.getTime()).toBe(ts)
-      expect(decoded.isDone).toBe(true)
+      const subscription = client.onPaginatedUpdate_experimental(
+        ref,
+        { after: new Date(123) },
+        { initialNumItems: 10 },
+        callback
+      )
+      expect(callback.mock.calls[0][0]).toEqual({
+        results: [{ createdAt: new Date(123) }],
+        status: 'CanLoadMore',
+        loadMore
+      })
+      expect(subscription.getCurrentValue()).toEqual(callback.mock.calls[0][0])
+      expect(subscription.getCurrentValue()!.loadMore(5)).toBe(true)
+      expect(loadMore).toHaveBeenCalledWith(5)
+      expect(subscription.getQueryLogs()).toEqual(['query log'])
+      wire = { results: [{ createdAt: 'invalid' }], status: 'Exhausted', loadMore }
+      expect(() => subscription.getCurrentValue()).toThrow()
+      wire = undefined
+      expect(subscription.getCurrentValue()).toBeUndefined()
+      subscription()
+      subscription.unsubscribe()
+      expect(stop).toHaveBeenCalledTimes(2)
     })
+  })
+
+  it('supports older paginated handles and surfaces callback codec failures', () => {
+    const native = Object.assign(vi.fn(), {
+      unsubscribe: vi.fn(),
+      getCurrentValue: () => undefined
+    })
+    let emit: (value: unknown) => void = () => undefined
+    mocks.paginatedImpl = (_ref, _args, _options, callback) => {
+      emit = callback
+      return native
+    }
+    const client = createZodvexClient(
+      {
+        'tasks:page': { returns: z.object({ page: z.array(z.object({ createdAt: zx.date() })) }) }
+      },
+      { url: 'https://test.convex.cloud', onDecodeError: 'warn' }
+    )
+    const subscription = client.onPaginatedUpdate_experimental(
+      fakeRef('tasks:page'),
+      {},
+      { initialNumItems: 10 },
+      vi.fn()
+    )
+    expect(subscription.getQueryLogs()).toBeUndefined()
+    expect(() =>
+      emit({ results: [{ createdAt: 'bad' }], status: 'Exhausted', loadMore: () => false })
+    ).toThrow()
+  })
+
+  it('routes pagination decode failures to onError without swallowing consumer errors', () => {
+    let emit: (value: unknown) => void = () => undefined
+    mocks.paginatedImpl = (_ref, _args, _options, callback) => {
+      emit = callback
+      return Object.assign(vi.fn(), { unsubscribe: vi.fn(), getCurrentValue: () => undefined })
+    }
+    const client = createZodvexClient(
+      {
+        'tasks:page': { returns: z.object({ page: z.array(z.object({ createdAt: zx.date() })) }) }
+      },
+      { url: 'https://test.convex.cloud' }
+    )
+    const onError = vi.fn()
+    const callback = vi.fn(() => {
+      throw new Error('consumer failure')
+    })
+    client.onPaginatedUpdate_experimental(
+      fakeRef('tasks:page'),
+      {},
+      { initialNumItems: 10 },
+      callback,
+      onError
+    )
+    emit({ results: [{ createdAt: 'bad' }], status: 'Exhausted', loadMore: () => false })
+    expect(onError).toHaveBeenCalledOnce()
+    expect(callback).not.toHaveBeenCalled()
+    expect(() =>
+      emit({ results: [{ createdAt: 123 }], status: 'Exhausted', loadMore: () => false })
+    ).toThrow('consumer failure')
+    expect(onError).toHaveBeenCalledOnce()
   })
 
   // ---- subscribe ----------------------------------------------------------

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.9",
+  "version": "0.7.10-beta.0",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -115,15 +115,18 @@
     "ts-morph": "^25.0.0"
   },
   "devDependencies": {
-    "zod": "4.5.4",
-    "zod-to-mini": "workspace:*",
     "@biomejs/biome": "^2.2.6",
     "@types/bun": "^1.3.0",
     "@types/node": "^24.8.0",
+    "@types/react": "19.2.14",
+    "@types/react-test-renderer": "19.1.0",
     "ai": "^6.0.6",
+    "react-test-renderer": "19.2.4",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "zod": "4.5.4",
+    "zod-to-mini": "workspace:*"
   },
   "engines": {
     "node": ">=20",

--- a/packages/zodvex/src/internal/boundaryHelpers.ts
+++ b/packages/zodvex/src/internal/boundaryHelpers.ts
@@ -14,7 +14,7 @@ import { $ZodError, safeParse } from './zod-core'
  */
 const functionNameSymbol = Symbol.for('functionName')
 
-function resolveFunctionPath(ref: FunctionReference<any, any, any, any>): string | null {
+export function resolveFunctionPath(ref: FunctionReference<any, any, any, any>): string | null {
   if (typeof ref === 'string') return ref
   const name = (ref as any)[functionNameSymbol]
   if (!name) return null

--- a/packages/zodvex/src/internal/paginationCodec.ts
+++ b/packages/zodvex/src/internal/paginationCodec.ts
@@ -1,0 +1,60 @@
+import type { FunctionReference } from 'convex/server'
+import { createBoundaryHelpers, resolveFunctionPath } from './boundaryHelpers'
+import type { AnyRegistry } from './types'
+import { $ZodArray, $ZodObject, clone } from './zod-core'
+
+/** Aggregate pagination only exposes items, not the original page envelopes. */
+export function createPaginationCodec(registry: AnyRegistry) {
+  const argsRegistry: AnyRegistry = Object.create(null)
+  const resultsRegistry: AnyRegistry = Object.create(null)
+  const argsCodec = createBoundaryHelpers(argsRegistry, { onDecodeError: 'throw' })
+  const resultsCodec = createBoundaryHelpers(resultsRegistry, { onDecodeError: 'throw' })
+
+  function unsupported(path: string, boundary: string): never {
+    throw new Error(
+      `[zodvex] Unsupported pagination ${boundary} schema for "${path}". ` +
+        'Use an unrefined argument object and an unrefined return object with an unrefined page array. ' +
+        'Item schemas may contain codecs and refinements. For whole-page checks or transforms, ' +
+        'use query or subscribe with explicit paginationOpts.'
+    )
+  }
+
+  function encodeArgs(ref: FunctionReference<'query'>, args: unknown): any {
+    const path = resolveFunctionPath(ref)
+    if (path !== null && !Object.hasOwn(argsRegistry, path)) {
+      const schema = registry[path]?.args
+      if (schema) {
+        if (!(schema instanceof $ZodObject) || schema._zod.def.checks?.length) {
+          unsupported(path, 'argument')
+        }
+        const { paginationOpts: _paginationOpts, ...shape } = schema._zod.def.shape
+        argsRegistry[path] = { args: clone(schema, { ...schema._zod.def, shape }) }
+      } else {
+        argsRegistry[path] = {}
+      }
+    }
+    return argsCodec.encodeArgs(ref, args)
+  }
+
+  function decodeResults(ref: FunctionReference<'query'>, results: unknown[]): any[] {
+    const path = resolveFunctionPath(ref)
+    if (path !== null && !Object.hasOwn(resultsRegistry, path)) {
+      const schema = registry[path]?.returns
+      if (schema) {
+        if (!(schema instanceof $ZodObject) || schema._zod.def.checks?.length) {
+          unsupported(path, 'return')
+        }
+        const page = schema._zod.def.shape.page
+        if (!(page instanceof $ZodArray) || page._zod.def.checks?.length) {
+          unsupported(path, 'page')
+        }
+        resultsRegistry[path] = { returns: page }
+      } else {
+        resultsRegistry[path] = {}
+      }
+    }
+    return resultsCodec.decodeResult(ref, results)
+  }
+
+  return { encodeArgs, decodeResults }
+}

--- a/packages/zodvex/src/public/cli/init.ts
+++ b/packages/zodvex/src/public/cli/init.ts
@@ -77,6 +77,7 @@ import { zodvexRegistry } from './api'
 
 export const useZodQuery = undefined as any
 export const useZodMutation = undefined as any
+export const useZodPaginatedQuery = undefined as any
 export const useQuery_experimental = undefined as any
 export const createClient = undefined as any
 `

--- a/packages/zodvex/src/public/client/index.ts
+++ b/packages/zodvex/src/public/client/index.ts
@@ -1,2 +1,2 @@
-export type { ZodvexClientOptions } from './zodvexClient'
+export type { PaginatedResult, PaginatedSubscription, ZodvexClientOptions } from './zodvexClient'
 export { createZodvexClient, ZodvexClient } from './zodvexClient'

--- a/packages/zodvex/src/public/client/zodvexClient.ts
+++ b/packages/zodvex/src/public/client/zodvexClient.ts
@@ -3,7 +3,21 @@ import { ConvexClient } from 'convex/browser'
 import type { FunctionArgs, FunctionReference, FunctionReturnType } from 'convex/server'
 import type { BoundaryHelpersOptions } from '../../internal/boundaryHelpers'
 import { createBoundaryHelpers } from '../../internal/boundaryHelpers'
+import { createPaginationCodec } from '../../internal/paginationCodec'
 import type { AnyRegistry } from '../../internal/types'
+
+/** Accumulated decoded items, with pagination controlled by Convex. */
+export type PaginatedResult<Item> = {
+  results: Item[]
+  status: 'LoadingFirstPage' | 'CanLoadMore' | 'LoadingMore' | 'Exhausted'
+  loadMore: (numItems: number) => boolean
+}
+
+export type PaginatedSubscription<Item> = (() => void) & {
+  unsubscribe: () => void
+  getCurrentValue: () => PaginatedResult<Item> | undefined
+  getQueryLogs: () => string[] | undefined
+}
 
 export type ZodvexClientOptions = (
   | { url: string; token?: string | null }
@@ -18,12 +32,14 @@ function tokenToFetcher(token: string): AuthTokenFetcher {
 
 export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
   private codec: ReturnType<typeof createBoundaryHelpers>
+  private paginationCodec: ReturnType<typeof createPaginationCodec>
   private innerClient?: ConvexClient
   private url?: string
   private pendingAuthFetcher?: AuthTokenFetcher
   private pendingAuthOnChange?: (isAuthenticated: boolean) => void
 
   constructor(registry: R, options: ZodvexClientOptions) {
+    this.paginationCodec = createPaginationCodec(registry)
     this.codec = createBoundaryHelpers(registry, {
       onDecodeError: options.onDecodeError,
       warnWirePreview: options.warnWirePreview
@@ -128,34 +144,62 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
   }
 
   /**
-   * Experimental paginated subscription. Encodes args to wire and decodes each
-   * page item through the registry, mirroring {@link subscribe}.
+   * Experimental Convex pagination with encoded filters and strictly decoded items.
+   * Returns accumulated results, not page envelopes. Both callbacks and current-value
+   * reads decode items; whole-page checks require explicit paginationOpts queries.
    */
-  onPaginatedUpdate_experimental<Q extends FunctionReference<'query', any, any, any>>(
+  onPaginatedUpdate_experimental<
+    Q extends FunctionReference<
+      'query',
+      'public',
+      any,
+      { page: any[]; isDone: boolean; continueCursor: string }
+    >
+  >(
     ref: Q,
-    args: Q['_args'],
+    args: Omit<FunctionArgs<Q>, 'paginationOpts'>,
     options: { initialNumItems: number },
-    callback: (result: {
-      page: Q['_returnType'][]
-      isDone: boolean
-      continueCursor: string
-      [key: string]: unknown
-    }) => void,
+    callback: (result: PaginatedResult<FunctionReturnType<Q>['page'][number]>) => void,
     onError?: (e: Error) => void
-  ): ReturnType<ConvexClient['onPaginatedUpdate_experimental']> {
-    const wireArgs = this.codec.encodeArgs(ref, args) as FunctionArgs<Q>
-    return this.getConvex().onPaginatedUpdate_experimental(
+  ): PaginatedSubscription<FunctionReturnType<Q>['page'][number]> {
+    const wireArgs = this.paginationCodec.encodeArgs(ref, args)
+    const decode = (wire: PaginatedResult<unknown>) => ({
+      ...wire,
+      results: this.paginationCodec.decodeResults(ref, wire.results)
+    })
+    // Convex's experimental callback declaration describes a page envelope, but its
+    // implementation dispatches aggregate results. Keep that SDK mismatch at this boundary.
+    const nativeCallback = ((wire: PaginatedResult<unknown>) => {
+      let decoded: ReturnType<typeof decode>
+      try {
+        decoded = decode(wire)
+      } catch (error) {
+        if (!onError) throw error
+        onError(
+          error instanceof Error
+            ? error
+            : new Error('Failed to decode paginated results', { cause: error })
+        )
+        return
+      }
+      callback(decoded)
+    }) as unknown as Parameters<ConvexClient['onPaginatedUpdate_experimental']>[3]
+    const native = this.getConvex().onPaginatedUpdate_experimental(
       ref,
       wireArgs,
       options,
-      (wireResult: any) => {
-        callback({
-          ...wireResult,
-          page: wireResult.page.map((item: any) => this.codec.decodeResult(ref, item))
-        })
-      },
+      nativeCallback,
       onError
-    ) as ReturnType<ConvexClient['onPaginatedUpdate_experimental']>
+    )
+    const withLogs = native as typeof native & { getQueryLogs?: () => string[] | undefined }
+    return Object.assign(() => native(), {
+      unsubscribe: () => native.unsubscribe(),
+      getCurrentValue: () => {
+        const wire = native.getCurrentValue()
+        return wire === undefined ? undefined : decode(wire)
+      },
+      getQueryLogs: () => withLogs.getQueryLogs?.()
+    })
   }
 
   /**

--- a/packages/zodvex/src/public/client/zodvexClient.ts
+++ b/packages/zodvex/src/public/client/zodvexClient.ts
@@ -1,6 +1,11 @@
 import type { AuthTokenFetcher, ConnectionState, MutationOptions } from 'convex/browser'
 import { ConvexClient } from 'convex/browser'
-import type { FunctionArgs, FunctionReference, FunctionReturnType } from 'convex/server'
+import type {
+  FunctionArgs,
+  FunctionReference,
+  FunctionReturnType,
+  PaginationOptions
+} from 'convex/server'
 import type { BoundaryHelpersOptions } from '../../internal/boundaryHelpers'
 import { createBoundaryHelpers } from '../../internal/boundaryHelpers'
 import { createPaginationCodec } from '../../internal/paginationCodec'
@@ -152,7 +157,7 @@ export class ZodvexClient<R extends AnyRegistry = AnyRegistry> {
     Q extends FunctionReference<
       'query',
       'public',
-      any,
+      { paginationOpts?: PaginationOptions },
       { page: any[]; isDone: boolean; continueCursor: string }
     >
   >(

--- a/packages/zodvex/src/public/codegen/generate.ts
+++ b/packages/zodvex/src/public/codegen/generate.ts
@@ -690,7 +690,7 @@ export function generateClientFile(options?: { mini?: boolean }): GeneratedFile 
   ]
 
   const jsExports = [
-    'export const { useZodQuery, useZodMutation, useQuery_experimental } = createZodvexHooks(zodvexRegistry)',
+    'export const { useZodQuery, useZodMutation, useZodPaginatedQuery, useQuery_experimental } = createZodvexHooks(zodvexRegistry)',
     '',
     'export const createClient = (options) =>',
     '  createZodvexClient(zodvexRegistry, options)',
@@ -713,6 +713,7 @@ export function generateClientFile(options?: { mini?: boolean }): GeneratedFile 
 
   const dtsDeclarations = [
     "export declare const useZodQuery: ZodvexHooks['useZodQuery']",
+    "export declare const useZodPaginatedQuery: ZodvexHooks['useZodPaginatedQuery']",
     "export declare const useQuery_experimental: ZodvexHooks['useQuery_experimental']",
     "export declare const useZodMutation: ZodvexHooks['useZodMutation']",
     '',

--- a/packages/zodvex/src/public/react/hooks.ts
+++ b/packages/zodvex/src/public/react/hooks.ts
@@ -5,7 +5,12 @@ import type {
 } from 'convex/react'
 import * as convexReact from 'convex/react'
 import { useMutation, usePaginatedQuery, useQuery } from 'convex/react'
-import type { FunctionArgs, FunctionReference, FunctionReturnType } from 'convex/server'
+import type {
+  FunctionArgs,
+  FunctionReference,
+  FunctionReturnType,
+  PaginationOptions
+} from 'convex/server'
 import { useMemo } from 'react'
 import type { BoundaryHelpersOptions } from '../../internal/boundaryHelpers'
 import { createBoundaryHelpers, resolveFunctionPath } from '../../internal/boundaryHelpers'
@@ -77,7 +82,7 @@ export function createZodvexHooks<R extends AnyRegistry>(
     Query extends FunctionReference<
       'query',
       'public',
-      any,
+      { paginationOpts?: PaginationOptions },
       { page: any[]; isDone: boolean; continueCursor: string }
     >
   >(

--- a/packages/zodvex/src/public/react/hooks.ts
+++ b/packages/zodvex/src/public/react/hooks.ts
@@ -1,9 +1,15 @@
-import type { OptionalRestArgsOrSkip } from 'convex/react'
+import type {
+  OptionalRestArgsOrSkip,
+  PaginatedQueryReference,
+  UsePaginatedQueryResult
+} from 'convex/react'
 import * as convexReact from 'convex/react'
-import { useMutation, useQuery } from 'convex/react'
+import { useMutation, usePaginatedQuery, useQuery } from 'convex/react'
 import type { FunctionArgs, FunctionReference, FunctionReturnType } from 'convex/server'
+import { useMemo } from 'react'
 import type { BoundaryHelpersOptions } from '../../internal/boundaryHelpers'
-import { createBoundaryHelpers } from '../../internal/boundaryHelpers'
+import { createBoundaryHelpers, resolveFunctionPath } from '../../internal/boundaryHelpers'
+import { createPaginationCodec } from '../../internal/paginationCodec'
 import type { AnyRegistry } from '../../internal/types'
 
 /** Query state, with failures omitted when throwOnError is enabled. */
@@ -56,10 +62,49 @@ export function createZodvexHooks<R extends AnyRegistry>(
   options?: BoundaryHelpersOptions
 ) {
   const codec = createBoundaryHelpers(registry, options)
+  const paginationCodec = createPaginationCodec(registry)
   const experimentalCodec = createBoundaryHelpers(registry, {
     ...options,
     onDecodeError: options?.onDecodeError ?? 'throw'
   })
+
+  /**
+   * Convex pagination with encoded filters and decoded items. Pagination metadata
+   * stays under Convex's control. Codec errors throw, including in warn mode.
+   * Outer object/array refinements and transforms require explicit page queries.
+   */
+  function useZodPaginatedQuery<
+    Query extends FunctionReference<
+      'query',
+      'public',
+      any,
+      { page: any[]; isDone: boolean; continueCursor: string }
+    >
+  >(
+    ref: Query,
+    args: Omit<FunctionArgs<Query>, 'paginationOpts'> | 'skip',
+    paginationOptions: { initialNumItems: number }
+  ): UsePaginatedQueryResult<FunctionReturnType<Query>['page'][number]> {
+    let wireArgs: any = 'skip'
+    let encodeFailure: { error: unknown } | undefined
+    if (args !== 'skip') {
+      try {
+        wireArgs = paginationCodec.encodeArgs(ref, args)
+      } catch (error) {
+        encodeFailure = { error }
+      }
+    }
+    const state = usePaginatedQuery(ref as PaginatedQueryReference, wireArgs, paginationOptions)
+    const skipped = wireArgs === 'skip'
+    const queryKey = resolveFunctionPath(ref) ?? ref
+    const results = useMemo(
+      () => (skipped ? state.results : paginationCodec.decodeResults(ref, state.results)),
+      [queryKey, state.results, skipped]
+    )
+    // Call both hooks on failed encodes too, so a failure never changes hook order.
+    if (encodeFailure) throw encodeFailure.error
+    return { ...state, results }
+  }
 
   /**
    * Convex's object-form query hook with decoded arguments and results (Convex >=1.37).
@@ -196,7 +241,7 @@ export function createZodvexHooks<R extends AnyRegistry>(
     }
   }
 
-  return { useZodQuery, useZodMutation, useQuery_experimental }
+  return { useZodQuery, useZodMutation, useZodPaginatedQuery, useQuery_experimental }
 }
 
 /**

--- a/packages/zodvex/typechecks/react-pagination.test-d.ts
+++ b/packages/zodvex/typechecks/react-pagination.test-d.ts
@@ -1,0 +1,21 @@
+import { makeFunctionReference } from 'convex/server'
+import { createZodvexHooks } from '../src/public/react/hooks'
+const { useZodPaginatedQuery } = createZodvexHooks({})
+const ref = makeFunctionReference<'query', { after: Date; paginationOpts?: {cursor: string | null; numItems: number} }, {page: {at: Date}[]; isDone:boolean; continueCursor:string}>('tasks:list')
+const args = Math.random() ? { after: new Date() } : 'skip'
+const result = useZodPaginatedQuery(ref, args, {initialNumItems:10})
+result.results[0].at.getTime()
+// @ts-expect-error decoded Date cannot be treated as a number
+const number: number = result.results[0].at
+// @ts-expect-error Date filters require runtime values
+useZodPaginatedQuery(ref, { after: 123 }, {initialNumItems:10})
+// @ts-expect-error Convex manages paginationOpts
+useZodPaginatedQuery(ref, { after: new Date(), paginationOpts: {cursor:null,numItems:10} }, {initialNumItems:10})
+// @ts-expect-error required domain args cannot be omitted
+useZodPaginatedQuery(ref, {}, {initialNumItems:10})
+// @ts-expect-error only paginated queries may be used
+useZodPaginatedQuery(makeFunctionReference<'query', {}, string>('tasks:get'), {}, {initialNumItems:10})
+
+function wrap<Q extends import('convex/server').FunctionReference<'query', 'public'>>(query: Q, args: Omit<import('convex/server').FunctionArgs<Q>, 'paginationOpts'> | 'skip') {
+  return useZodPaginatedQuery(query, args, {initialNumItems:10})
+}

--- a/packages/zodvex/typechecks/react-pagination.test-d.ts
+++ b/packages/zodvex/typechecks/react-pagination.test-d.ts
@@ -19,3 +19,13 @@ useZodPaginatedQuery(makeFunctionReference<'query', {}, string>('tasks:get'), {}
 function wrap<Q extends import('convex/server').FunctionReference<'query', 'public'>>(query: Q, args: Omit<import('convex/server').FunctionArgs<Q>, 'paginationOpts'> | 'skip') {
   return useZodPaginatedQuery(query, args, {initialNumItems:10})
 }
+
+const missingPagination = makeFunctionReference<'query', {after:Date}, {page:{at:Date}[];isDone:boolean;continueCursor:string}>('tasks:missingPagination')
+// @ts-expect-error explicit domain-only args do not support pagination
+useZodPaginatedQuery(missingPagination, {after:new Date()}, {initialNumItems:10})
+const vanilla = import('../src/public/client/zodvexClient').then(({createZodvexClient}) => {
+  const client = createZodvexClient({}, {url:'https://test.convex.cloud'})
+  client.onPaginatedUpdate_experimental(ref, {after:new Date()}, {initialNumItems:10}, result => result.results[0].at.getTime())
+  // @ts-expect-error explicit domain-only args do not support pagination
+  client.onPaginatedUpdate_experimental(missingPagination, {after:new Date()}, {initialNumItems:10}, () => undefined)
+})


### PR DESCRIPTION
Hotpot currently wraps Convex's paginated React hook with a fabricated page envelope to decode accumulated items. Zodvex's experimental vanilla wrapper also expects a page envelope even though Convex supplies aggregate results, so it fails on real responses.

Add generated `useZodPaginatedQuery` and repair `onPaginatedUpdate_experimental` using a shared codec boundary. Convex retains pagination, cursors, page splitting and loading state; Zodvex encodes domain arguments and decodes accumulated items. Vanilla callbacks and current-value reads both return decoded results, with unsubscribe and loadMore preserved.

Aggregate decoding is strict and item-scoped. Outer argument/return transforms or refinements and page-array checks are rejected rather than silently dropped; complete-page validation remains available through explicit paginationOpts queries. This supersedes the restriction-only approach in draft #123.

Validation: full Node 22 local gate (2,320 library tests across full Zod/Mini, codegen, examples and declaration checks); packed real React/native Convex pagination plus strict consumer declarations on Convex 1.28.0 and 1.45.0; independent subagent review. An isolated Hotpot trial removed its synthetic-envelope wrapper and passed 1,799 tests plus four CLI tests, build, type checks and lint on Convex 1.45.0. No Hotpot deployment or MR changes.

Release preparation: package and workspace lock versions are now `0.7.10-beta.0`; publish through the release workflow to npm's `beta` tag after merge. Stable `latest` remains 0.7.9.

Type design: both APIs structurally constrain arguments to `{ paginationOpts?: PaginationOptions }`. This rejects explicitly domain-only arguments while preserving Hotpot's optional pagination arguments and generic wrapper composition. Negative React/vanilla checks and the positive composition check pass. Changelog and the shared-client callback error caveat are documented.
