### PR TITLE
chore(release): prepare stable 0.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.10] - 2026-09-08
+
 ### Added
 
 - Generated clients and `createZodvexHooks` expose `useZodPaginatedQuery`, with encoded filters and decoded accumulated items while Convex manages pagination. Aggregate pagination uses strict item decoding and rejects unsupported outer schema checks rather than silently dropping them.

--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
     "packages/zodvex": {
       "name": "zodvex",
-      "version": "0.7.10-beta.0",
+      "version": "0.7.10",
       "bin": {
         "zodvex": "./dist/cli/index.js",
       },

--- a/docs/releases/v0.7.10.md
+++ b/docs/releases/v0.7.10.md
@@ -1,0 +1,17 @@
+# Zodvex 0.7.10
+
+Generated clients now export `useZodPaginatedQuery`. It encodes domain arguments and decodes accumulated items while Convex manages subscriptions, cursors, page splitting, loading state and `loadMore`.
+
+```tsx
+const { results, status, isLoading, loadMore } = useZodPaginatedQuery(
+  api.messages.list,
+  { visitId },
+  { initialNumItems: 25 }
+)
+```
+
+Pass domain arguments or `'skip'`; Convex supplies `paginationOpts`. Argument schemas must be ordinary objects, and return schemas must be ordinary objects with `page: z.array(itemSchema)`. Item codecs and refinements are preserved. Outer argument/return refinements or transforms and page-array checks are rejected rather than silently dropped. Use explicit `paginationOpts` with ordinary queries or subscriptions when you need complete-page validation.
+
+The experimental vanilla `onPaginatedUpdate_experimental` method now handles Convex's actual `{ results, status, loadMore }` response instead of expecting a page envelope. Its callback and subscription `getCurrentValue()` both return decoded items. `PaginatedResult` and `PaginatedSubscription` describe this interface. Callback decode failures go to `onError` when supplied; current-value decode failures throw. Provide `onError` on shared clients so a malformed result does not interrupt sibling callbacks in that update.
+
+Aggregate pagination decodes strictly, including when other methods use `onDecodeError: 'warn'`. Existing ordinary query hooks keep their behavior. Install 0.7.10 and rerun `zodvex generate` to add the new export. Convex's existing >=1.28 peer range is unchanged.

--- a/packages/zodvex/package.json
+++ b/packages/zodvex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zodvex",
-  "version": "0.7.10-beta.0",
+  "version": "0.7.10",
   "description": "Codec-first Zod v4 integration for Convex -- type-safe validation, encoding, DB wrapping, and codegen.",
   "keywords": ["zod", "convex", "validators", "codec", "mapping", "schema", "validation"],
   "homepage": "https://github.com/panzacoder/zodvex#readme",


### PR DESCRIPTION
Promote the validated 0.7.10-beta.0 implementation to stable 0.7.10. Update the package/workspace lock version, move the changelog entries into 0.7.10, and add release notes covering React pagination, the repaired vanilla subscription contract, and strict aggregate decoding.

No runtime changes from the published beta. That package passed Hotpot's 1,799 tests plus four CLI tests, build, type checks and lint, along with a multi-page SensitiveField consumer check. The beta implementation also passed Zodvex's full local gate and Convex 1.28/1.45 compatibility checks. Stable publication uses the existing release workflow and npm latest tag.
