### PR TITLE
refactor: simplify builder construction

### DIFF
--- a/packages/zodvex/src/internal/builders.ts
+++ b/packages/zodvex/src/internal/builders.ts
@@ -1,20 +1,9 @@
-import type {
-  FunctionVisibility,
-  RegisteredAction,
-  RegisteredMutation,
-  RegisteredQuery
-} from 'convex/server'
+import type { FunctionVisibility } from 'convex/server'
 import type { PropertyValidators } from 'convex/values'
 import type { Customization } from 'convex-helpers/server/customFunctions'
 import { type CustomBuilder, customFnBuilder } from './custom'
 import { attachFunctionMeta } from './functionContracts'
-import type {
-  ExtractCtx,
-  ExtractVisibility,
-  InferHandlerReturns,
-  InferReturns,
-  ZodToConvexArgs
-} from './types'
+import type { ExtractCtx, ExtractVisibility, InferHandlerReturns, ZodToConvexArgs } from './types'
 import { zAction, zMutation, zQuery } from './wrappers'
 import { $ZodType } from './zod-core'
 
@@ -56,46 +45,6 @@ function registerBuilderFunction<
   return result
 }
 
-function createDirectBuilderFactory(
-  register: (builder: any, input: any, handler: any, options: any) => any
-) {
-  return function directBuilderFactory<Builder extends (fn: any) => any>(builder: Builder) {
-    return <
-      A extends $ZodType | Record<string, $ZodType>,
-      R extends $ZodType | undefined = undefined
-    >(
-      config: BuilderConfig<Builder, A, R>
-    ): any => registerBuilderFunction(register as any, builder, config) as any
-  }
-}
-
-function createCustomBuilderFactory() {
-  return function customBuilderFactory<
-    Builder extends (fn: any) => any,
-    CustomArgsValidator extends PropertyValidators,
-    CustomCtx extends Record<string, any>,
-    CustomMadeArgs extends Record<string, any>,
-    Visibility extends FunctionVisibility = ExtractVisibility<Builder>,
-    ExtraArgs extends Record<string, any> = Record<string, any>
-  >(
-    builder: Builder,
-    customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
-  ): CustomBuilder<
-    'query' | 'mutation' | 'action',
-    CustomArgsValidator,
-    CustomCtx,
-    CustomMadeArgs,
-    ExtractCtx<Builder>,
-    Visibility,
-    ExtraArgs
-  > {
-    return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
-      builder as any,
-      customization as any
-    ) as any
-  }
-}
-
 /**
  * Creates a reusable query builder from a Convex query builder.
  * Returns a builder function that accepts Convex-style config objects with args, handler, and returns.
@@ -119,8 +68,13 @@ function createCustomBuilderFactory() {
  * })
  * ```
  */
-export function zQueryBuilder<Builder extends (fn: any) => any>(builder: Builder) {
-  return createDirectBuilderFactory(zQuery)(builder) as any
+export function zQueryBuilder<Builder extends (fn: any) => any>(builder: Builder): any {
+  return <
+    A extends $ZodType | Record<string, $ZodType>,
+    R extends $ZodType | undefined = undefined
+  >(
+    config: BuilderConfig<Builder, A, R>
+  ): any => registerBuilderFunction(zQuery, builder, config)
 }
 
 /**
@@ -146,8 +100,13 @@ export function zQueryBuilder<Builder extends (fn: any) => any>(builder: Builder
  * })
  * ```
  */
-export function zMutationBuilder<Builder extends (fn: any) => any>(builder: Builder) {
-  return createDirectBuilderFactory(zMutation)(builder) as any
+export function zMutationBuilder<Builder extends (fn: any) => any>(builder: Builder): any {
+  return <
+    A extends $ZodType | Record<string, $ZodType>,
+    R extends $ZodType | undefined = undefined
+  >(
+    config: BuilderConfig<Builder, A, R>
+  ): any => registerBuilderFunction(zMutation, builder, config)
 }
 
 /**
@@ -173,8 +132,13 @@ export function zMutationBuilder<Builder extends (fn: any) => any>(builder: Buil
  * })
  * ```
  */
-export function zActionBuilder<Builder extends (fn: any) => any>(builder: Builder) {
-  return createDirectBuilderFactory(zAction)(builder) as any
+export function zActionBuilder<Builder extends (fn: any) => any>(builder: Builder): any {
+  return <
+    A extends $ZodType | Record<string, $ZodType>,
+    R extends $ZodType | undefined = undefined
+  >(
+    config: BuilderConfig<Builder, A, R>
+  ): any => registerBuilderFunction(zAction, builder, config)
 }
 
 /**
@@ -226,7 +190,10 @@ export function zCustomQueryBuilder<
   Visibility,
   ExtraArgs
 > {
-  return createCustomBuilderFactory()(query, customization) as any
+  return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
+    query,
+    customization
+  ) as any
 }
 
 /**
@@ -278,7 +245,10 @@ export function zCustomMutationBuilder<
   Visibility,
   ExtraArgs
 > {
-  return createCustomBuilderFactory()(mutation, customization) as any
+  return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
+    mutation,
+    customization
+  ) as any
 }
 
 /**
@@ -331,5 +301,8 @@ export function zCustomActionBuilder<
   Visibility,
   ExtraArgs
 > {
-  return createCustomBuilderFactory()(action, customization) as any
+  return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
+    action,
+    customization
+  ) as any
 }

--- a/packages/zodvex/src/internal/builders.ts
+++ b/packages/zodvex/src/internal/builders.ts
@@ -193,7 +193,7 @@ export function zCustomQueryBuilder<
   return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
     query,
     customization
-  ) as any
+  )
 }
 
 /**
@@ -248,7 +248,7 @@ export function zCustomMutationBuilder<
   return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
     mutation,
     customization
-  ) as any
+  )
 }
 
 /**
@@ -304,5 +304,5 @@ export function zCustomActionBuilder<
   return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
     action,
     customization
-  ) as any
+  )
 }

--- a/packages/zodvex/src/internal/custom.ts
+++ b/packages/zodvex/src/internal/custom.ts
@@ -294,22 +294,6 @@ export function customFnBuilder<
   }
 }
 
-function createCustomBuilderEntrypoint<
-  Builder extends (fn: any) => any,
-  CustomArgsValidator extends PropertyValidators,
-  CustomCtx extends Record<string, any>,
-  CustomMadeArgs extends Record<string, any>,
-  ExtraArgs extends Record<string, any> = Record<string, any>
->(
-  builder: Builder,
-  customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
-) {
-  return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
-    builder as any,
-    customization as any
-  ) as any
-}
-
 // Overload 1: With constraint - preferred to preserve DataModel types
 export function zCustomQuery<
   CustomArgsValidator extends PropertyValidators,
@@ -362,17 +346,14 @@ export function zCustomQuery<
   query: QueryBuilder<any, Visibility>,
   customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
 ) {
-  // Cast justification: This is the TypeScript overload implementation pattern. The function
-  // has two overloads (with/without DataModel constraint) that provide precise types to callers.
-  // The implementation must satisfy both overloads, which requires a broader signature.
-  // The 'as any' casts allow the implementation to delegate to customFnBuilder without
-  // TypeScript complaining about the generic parameter differences between overloads.
-  // This is type-safe because: (1) callers only see the overload signatures which are strict,
-  // (2) the runtime behavior is identical regardless of which overload matched.
-  // TODO: Consider using a conditional type or branded types to create a single signature
-  // that satisfies both overloads without casts. Alternatively, accept this as idiomatic
-  // TypeScript for overloaded functions and keep the casts.
-  return createCustomBuilderEntrypoint(query, customization)
+  return customFnBuilder<
+    any,
+    QueryBuilder<any, Visibility>,
+    CustomArgsValidator,
+    CustomCtx,
+    CustomMadeArgs,
+    ExtraArgs
+  >(query, customization) as any
 }
 
 // Overload 1: With constraint - preferred to preserve DataModel types
@@ -408,9 +389,10 @@ export function zCustomMutation<
   mutation: Builder,
   customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
 ) {
-  // Cast justification: Same overload implementation pattern as zCustomQuery.
-  // See detailed comment there. Type safety is enforced by the overload signature above.
-  return createCustomBuilderEntrypoint(mutation, customization)
+  return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
+    mutation,
+    customization
+  ) as any
 }
 
 // Overload 1: With constraint - preferred to preserve DataModel types
@@ -446,7 +428,8 @@ export function zCustomAction<
   action: Builder,
   customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
 ) {
-  // Cast justification: Same overload implementation pattern as zCustomQuery.
-  // See detailed comment there. Type safety is enforced by the overload signature above.
-  return createCustomBuilderEntrypoint(action, customization)
+  return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
+    action,
+    customization
+  ) as any
 }

--- a/packages/zodvex/src/internal/custom.ts
+++ b/packages/zodvex/src/internal/custom.ts
@@ -353,7 +353,7 @@ export function zCustomQuery<
     CustomCtx,
     CustomMadeArgs,
     ExtraArgs
-  >(query, customization) as any
+  >(query, customization)
 }
 
 // Overload 1: With constraint - preferred to preserve DataModel types
@@ -392,7 +392,7 @@ export function zCustomMutation<
   return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
     mutation,
     customization
-  ) as any
+  )
 }
 
 // Overload 1: With constraint - preferred to preserve DataModel types
@@ -431,5 +431,5 @@ export function zCustomAction<
   return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
     action,
     customization
-  ) as any
+  )
 }

--- a/packages/zodvex/src/internal/init.ts
+++ b/packages/zodvex/src/internal/init.ts
@@ -62,8 +62,6 @@ type InternalCustomization = {
   input: (ctx: any, args: any, extra?: any) => any
 }
 
-type InternalCustomFn = (builder: any, customization: any) => any
-
 type InitServerBuilders = {
   query: QueryBuilder<any, 'public'>
   mutation: MutationBuilder<any, 'public'>
@@ -328,7 +326,14 @@ export function initZodvex(
     action: actionCust
   }
 
-  return createInitBuilderBundle(server, customizations)
+  return {
+    zq: createZodvexBuilder(server.query, customizations.query, zCustomQuery),
+    zm: createZodvexBuilder(server.mutation, customizations.mutation, zCustomMutation),
+    za: createZodvexBuilder(server.action, customizations.action, zCustomAction),
+    ziq: createZodvexBuilder(server.internalQuery, customizations.query, zCustomQuery),
+    zim: createZodvexBuilder(server.internalMutation, customizations.mutation, zCustomMutation),
+    zia: createZodvexBuilder(server.internalAction, customizations.action, zCustomAction)
+  }
 }
 
 function createNoOpCustomization(): InternalCustomization {
@@ -383,44 +388,6 @@ function createMutationCustomization(
   }
 }
 
-function getInitBuilderSpecs(
-  server: InitServerBuilders,
-  customizations: {
-    query: InternalCustomization
-    mutation: InternalCustomization
-    action: InternalCustomization
-  }
-) {
-  return [
-    ['zq', server.query, customizations.query, zCustomQuery],
-    ['zm', server.mutation, customizations.mutation, zCustomMutation],
-    ['za', server.action, customizations.action, zCustomAction],
-    ['ziq', server.internalQuery, customizations.query, zCustomQuery],
-    ['zim', server.internalMutation, customizations.mutation, zCustomMutation],
-    ['zia', server.internalAction, customizations.action, zCustomAction]
-  ] as const
-}
-
-function createInitBuilderBundle(
-  server: InitServerBuilders,
-  customizations: {
-    query: InternalCustomization
-    mutation: InternalCustomization
-    action: InternalCustomization
-  }
-) {
-  const builders: Record<string, any> = {}
-
-  for (const [key, rawBuilder, customization, customFn] of getInitBuilderSpecs(
-    server,
-    customizations
-  )) {
-    builders[key] = createZodvexBuilder(rawBuilder, customization, customFn as InternalCustomFn)
-  }
-
-  return builders
-}
-
 /**
  * Composes a codec customization with a user customization.
  * Codec input runs first (wraps ctx.db), user input runs second
@@ -473,11 +440,11 @@ export function createZodvexBuilder(
   codecCust: InternalCustomization,
   customFn: (builder: any, customization: any) => any
 ) {
-  const base: any = customFn(rawBuilder as any, codecCust as any)
+  const base: any = customFn(rawBuilder, codecCust)
 
   base.withContext = (userCust: any) => {
     const composed = composeCustomizations(codecCust, userCust)
-    return customFn(rawBuilder as any, composed as any)
+    return customFn(rawBuilder, composed)
   }
 
   return base


### PR DESCRIPTION
Builder construction was spread across forwarding factories and a table-driven loop for six fixed entries. Register legacy and custom builders directly and return the six `initZodvex` builders as an explicit object, removing 77 lines while preserving metadata, customization composition, runtime behavior, and public types. Remove the redundant custom-entrypoint helper, its speculative cast commentary, and six unnecessary return assertions. The shared custom registration implementation remains broadly typed internally; this refactor does not claim to improve its type safety.

Validation: full local validation (2,320 library tests plus codemod/example checks); emitted declarations compared with 0.7.10 (identical excluding comments/whitespace); independent subagent review with no outstanding findings.
