### PR TITLE
fix(types): preserve parsed object argument output

### DIFF
--- a/packages/zodvex/src/internal/functionContracts.ts
+++ b/packages/zodvex/src/internal/functionContracts.ts
@@ -158,15 +158,15 @@ export function parseFunctionArgsOrThrow(zodSchema: $ZodType, argsObject: unknow
   }
 }
 
-export function parseObjectArgsOrThrow(
-  argsSchema: $ZodObject,
+export function parseObjectArgsOrThrow<S extends $ZodObject>(
+  argsSchema: S,
   rawArgs: Record<string, unknown>
-): Record<string, unknown> {
+): z.output<S> {
   const parsed = safeParse(argsSchema, rawArgs)
   if (!parsed.success) {
     handleZodValidationError(parsed.error, 'args')
   }
-  return parsed.data as Record<string, unknown>
+  return parsed.data
 }
 
 export async function runCustomizationInput(

--- a/packages/zodvex/typechecks/function-contracts.test-d.ts
+++ b/packages/zodvex/typechecks/function-contracts.test-d.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+import * as mini from 'zod/mini'
+import { parseObjectArgsOrThrow } from '../src/internal/functionContracts'
+import type { Equal, Expect } from './test-helpers'
+
+const at = z.codec(z.string(), z.date(), {
+  decode: value => new Date(value),
+  encode: value => value.toISOString()
+})
+const full = parseObjectArgsOrThrow(z.object({ at, n: z.number().default(1) }), {})
+type _Output = Expect<Equal<typeof full, { at: Date; n: number }>>
+full.at.getTime()
+// @ts-expect-error Decoded Date is not wire string
+const _wire: string = full.at
+// @ts-expect-error No unchecked keys
+full.missing
+const small = parseObjectArgsOrThrow(mini.object({ n: mini.number() }), {})
+type _MiniOutput = Expect<Equal<typeof small, { n: number }>>
+// @ts-expect-error Object parser rejects primitive schemas
+parseObjectArgsOrThrow(z.number(), {})


### PR DESCRIPTION
Object argument parsing discarded schema output types into `Record<string, unknown>`. Preserve the schema's inferred output instead, including decoded codecs, defaults, and mini schemas, without a return assertion.

Add compiler tests against the actual helper for precise output, invalid property access, decoded-versus-wire values, and rejection of primitive schemas. These tests fail against the previous implementation and pass with this change. Runtime JavaScript is unchanged; public declarations are unchanged.

Validation: full local gate (2,320 library tests plus codemod/example checks), emitted declaration comparison, and independent review. This improves the parsing boundary; normalization and modern registration still erase information and remain follow-up work.
