### PR TITLE
refactor: isolate schema IDs to remove import cycles

### DIFF
--- a/packages/zodvex/__tests__/runtime-import-cycles.test.ts
+++ b/packages/zodvex/__tests__/runtime-import-cycles.test.ts
@@ -1,0 +1,73 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+import { expect, test } from 'vitest'
+
+// Type-only cycles are harmless at module initialization. Keep static value
+// imports and re-exports acyclic so schema construction does not depend on
+// another module's partially initialized exports.
+test('source runtime imports have no cycles', () => {
+  const root = fileURLToPath(new URL('../src/', import.meta.url))
+  const files = readdirSync(root, { recursive: true })
+    .filter(file => file.endsWith('.ts'))
+    .map(file => path.join(root, file))
+  const graph = new Map(files.map(file => [file, [] as string[]]))
+
+  for (const file of files) {
+    const source = ts.createSourceFile(file, readFileSync(file, 'utf8'), ts.ScriptTarget.Latest)
+    for (const statement of source.statements) {
+      if (!ts.isImportDeclaration(statement) && !ts.isExportDeclaration(statement)) continue
+      const specifier = statement.moduleSpecifier
+      if (!specifier || !ts.isStringLiteral(specifier) || !specifier.text.startsWith('.')) continue
+      if (ts.isImportDeclaration(statement)) {
+        const clause = statement.importClause
+        if (clause?.isTypeOnly) continue
+        if (
+          clause &&
+          !clause.name &&
+          clause.namedBindings &&
+          ts.isNamedImports(clause.namedBindings) &&
+          clause.namedBindings.elements.length > 0 &&
+          clause.namedBindings.elements.every(element => element.isTypeOnly)
+        )
+          continue
+      } else {
+        if (statement.isTypeOnly) continue
+        const clause = statement.exportClause
+        if (
+          clause &&
+          ts.isNamedExports(clause) &&
+          clause.elements.length > 0 &&
+          clause.elements.every(element => element.isTypeOnly)
+        )
+          continue
+      }
+      const base = path.resolve(path.dirname(file), specifier.text)
+      const target = [`${base}.ts`, path.join(base, 'index.ts')].find(candidate =>
+        graph.has(candidate)
+      )
+      if (target) graph.get(file)?.push(target)
+    }
+  }
+
+  const visited = new Set<string>()
+  const stack: string[] = []
+  const cycles: string[] = []
+  function visit(file: string) {
+    const position = stack.indexOf(file)
+    if (position !== -1) {
+      cycles.push(
+        [...stack.slice(position), file].map(item => path.relative(root, item)).join(' → ')
+      )
+      return
+    }
+    if (visited.has(file)) return
+    visited.add(file)
+    stack.push(file)
+    for (const dependency of graph.get(file) ?? []) visit(dependency)
+    stack.pop()
+  }
+  for (const file of files) visit(file)
+  expect(cycles).toEqual([])
+})

--- a/packages/zodvex/src/internal/modelSchemaBundle.ts
+++ b/packages/zodvex/src/internal/modelSchemaBundle.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { id } from './schema/id'
 import {
   addSystemFields,
   createUnionFromOptions,
@@ -6,7 +7,6 @@ import {
   isZodUnion
 } from './schemaHelpers'
 import { $ZodNullable, $ZodObject, $ZodOptional, type $ZodShape, $ZodType } from './zod-core'
-import { zx } from './zx'
 
 // Return type alias so helper signatures don't expose full zod internals everywhere.
 type AnyOptional = z.ZodOptional<any> // zod-ok
@@ -47,7 +47,7 @@ export function createUpdateObjectSchema<Name extends string>(
   shape: Record<string, $ZodType>
 ): z.ZodObject<any> {
   return z.object({
-    _id: zx.id(name),
+    _id: id(name),
     _creationTime: z.optional(z.number()),
     ...createPartialShape(shape)
   })

--- a/packages/zodvex/src/internal/schema/id.ts
+++ b/packages/zodvex/src/internal/schema/id.ts
@@ -1,0 +1,52 @@
+import type { GenericId } from 'convex/values'
+import { z } from 'zod'
+import { registryHelpers } from '../ids'
+
+/**
+ * ID type for explicit type annotations
+ */
+export type ZxId<TableName extends string> = z.ZodString &
+  z.ZodType<GenericId<TableName>> & {
+    _tableName: TableName
+  }
+
+/**
+ * Creates a Convex ID validator for a specific table.
+ *
+ * Wire format: string (Convex ID)
+ * Runtime format: GenericId<TableName> (branded string type)
+ *
+ * Note: Unlike zx.date(), IDs don't require runtime transformation since
+ * GenericId<T> is a branded string type. The branding is purely type-level.
+ *
+ * @param tableName - The Convex table name for this ID
+ *
+ * @example
+ * ```typescript
+ * const schema = z.object({
+ *   userId: zx.id('users'),
+ *   teamId: zx.id('teams').optional(),
+ * })
+ * ```
+ */
+export function id<TableName extends string>(tableName: TableName): ZxId<TableName> {
+  // Create base string validator with refinement
+  const baseSchema = z.string().check(
+    z.refine(val => typeof val === 'string' && val.length > 0, {
+      message: `Invalid ID for table "${tableName}"`
+    }),
+    z.describe(`convexId:${tableName}`)
+  )
+
+  // Store metadata for registry lookup so mapping can convert to v.id(tableName)
+  registryHelpers.setMetadata(baseSchema, {
+    isConvexId: true,
+    tableName
+  })
+
+  // Add the tableName property for type-level detection
+  const branded = baseSchema as any
+  branded._tableName = tableName
+
+  return branded as ZxId<TableName>
+}

--- a/packages/zodvex/src/internal/schemaHelpers.ts
+++ b/packages/zodvex/src/internal/schemaHelpers.ts
@@ -11,6 +11,7 @@
  */
 
 import { z } from 'zod'
+import { id, type ZxId } from './schema/id'
 import {
   $ZodArray,
   $ZodDiscriminatedUnion,
@@ -21,7 +22,6 @@ import {
   $ZodUnion,
   clone
 } from './zod-core'
-import { type ZxId, zx } from './zx'
 
 // ============================================================================
 // Types
@@ -201,7 +201,7 @@ export function addSystemFields<TableName extends string>(
       if (variant instanceof $ZodObject) {
         const newShape = {
           ...variant._zod.def.shape,
-          _id: zx.id(tableName),
+          _id: id(tableName),
           _creationTime: z.number()
         }
         // Clone preserves the original's class + reinitializes with merged def
@@ -215,7 +215,7 @@ export function addSystemFields<TableName extends string>(
 
   // Handle object schemas — clone preserves class, checks, catchall, error
   if (schema instanceof $ZodObject) {
-    const newShape = { ...schema._zod.def.shape, _id: zx.id(tableName), _creationTime: z.number() }
+    const newShape = { ...schema._zod.def.shape, _id: id(tableName), _creationTime: z.number() }
     return clone(schema, { ...schema._zod.def, shape: newShape })
   }
 

--- a/packages/zodvex/src/internal/zx.ts
+++ b/packages/zodvex/src/internal/zx.ts
@@ -20,12 +20,11 @@
  * ```
  */
 
-import type { GenericId } from 'convex/values'
 import { z } from 'zod'
 import { zodvexCodec } from './codec'
-import { registryHelpers } from './ids'
 import { attachCodecBrand } from './meta'
 import { createSchemaUpdateSchema } from './modelSchemaBundle'
+import { id } from './schema/id'
 import { addSystemFields } from './schemaHelpers'
 import type { ZodvexCodec } from './types'
 import {
@@ -38,6 +37,8 @@ import {
   type output as zoutput
 } from './zod-core'
 import { brandZxDate } from './zxDateBrand'
+
+export type { ZxId } from './schema/id'
 
 /**
  * Date codec type for explicit type annotations
@@ -74,55 +75,6 @@ function date(): ZxDate {
       }
     )
   ) as unknown as ZxDate
-}
-
-/**
- * ID type for explicit type annotations
- */
-export type ZxId<TableName extends string> = z.ZodString &
-  z.ZodType<GenericId<TableName>> & {
-    _tableName: TableName
-  }
-
-/**
- * Creates a Convex ID validator for a specific table.
- *
- * Wire format: string (Convex ID)
- * Runtime format: GenericId<TableName> (branded string type)
- *
- * Note: Unlike zx.date(), IDs don't require runtime transformation since
- * GenericId<T> is a branded string type. The branding is purely type-level.
- *
- * @param tableName - The Convex table name for this ID
- *
- * @example
- * ```typescript
- * const schema = z.object({
- *   userId: zx.id('users'),
- *   teamId: zx.id('teams').optional(),
- * })
- * ```
- */
-function id<TableName extends string>(tableName: TableName): ZxId<TableName> {
-  // Create base string validator with refinement
-  const baseSchema = z.string().check(
-    z.refine(val => typeof val === 'string' && val.length > 0, {
-      message: `Invalid ID for table "${tableName}"`
-    }),
-    z.describe(`convexId:${tableName}`)
-  )
-
-  // Store metadata for registry lookup so mapping can convert to v.id(tableName)
-  registryHelpers.setMetadata(baseSchema, {
-    isConvexId: true,
-    tableName
-  })
-
-  // Add the tableName property for type-level detection
-  const branded = baseSchema as any
-  branded._tableName = tableName
-
-  return branded as ZxId<TableName>
 }
 
 /**


### PR DESCRIPTION
Schema helpers imported the full `zx` namespace solely to construct IDs, while `zx` imported those same schema helpers. Extract the existing ID function and type into a leaf module so schema construction no longer creates two circular runtime import paths.

Keep `zx.id`, metadata registration, and public types unchanged. Add a static import-graph regression test that fails on the previous cycles and passes after extraction. This is a dependency-organization fix; no existing initialization failure is claimed.

Validation: full local gate (2,322 library tests plus codemod/example checks), 134 focused ID/model tests, and declaration comparison showing all public entrypoints unchanged. Full and mini builds pass.
