### PR TITLE
fix: preserve types through modern function builders

### DIFF
--- a/packages/zodvex/__tests__/builder-pipeline.test.ts
+++ b/packages/zodvex/__tests__/builder-pipeline.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import * as mini from 'zod/mini'
+import { initZodvex } from '../src/internal/functions/init'
+
+// Capture the definition handed to Convex so the test can invoke its wire handler.
+const capture = (definition: any) => definition
+const server = {
+  query: capture,
+  mutation: capture,
+  action: capture,
+  internalQuery: capture,
+  internalMutation: capture,
+  internalAction: capture
+}
+
+describe.each([
+  'zq',
+  'zm',
+  'za',
+  'ziq',
+  'zim',
+  'zia'
+] as const)('%s customization pipeline', name => {
+  it.each([false, true])('decodes, overwrites and encodes (mini=%s)', useMini => {
+    const at = z.codec(z.string(), z.date(), {
+      decode: value => new Date(value),
+      encode: value => value.toISOString()
+    })
+    const count = useMini ? mini.number() : z.number()
+    const args = useMini ? mini.object({ count, at }) : z.object({ count, at })
+    const builder = initZodvex({ __zodTableMap: {} }, server, { wrapDb: false })[name]
+    const events: unknown[] = []
+    const customized = builder.withContext({
+      args: { token: at },
+      input: (ctx, input) => {
+        events.push(['input', input.token, ctx])
+        return {
+          ctx: { identity: 'custom' },
+          args: { count: 'replacement' },
+          onSuccess: ({ ctx, args, result }) => {
+            events.push(['success', ctx, args, result])
+          }
+        }
+      }
+    })
+    const definition = customized({
+      args,
+      returns: at,
+      handler: (ctx, value) => {
+        events.push(['handler', ctx, value])
+        return value.at
+      }
+    }) as any
+    const original = { identity: 'original' }
+    const date = new Date('2026-01-01T00:00:00.000Z')
+    return expect(
+      definition.handler(original, { count: 4, at: date.toISOString(), token: date.toISOString() })
+    )
+      .resolves.toBe(date.toISOString())
+      .then(() => {
+        expect(events).toEqual([
+          ['input', date, original],
+          ['handler', { identity: 'custom' }, { count: 'replacement', at: date }],
+          ['success', original, { count: 4, at: date }, date]
+        ])
+      })
+  })
+})
+
+describe('handler shorthand compatibility', () => {
+  it('forwards empty options for a plain handler', async () => {
+    const { customFnBuilder } = await import('../src/internal/functions/customFunctions')
+    const options: unknown[] = []
+    const builder = customFnBuilder(capture, {
+      args: {},
+      input: (_ctx, _args, extra) => {
+        options.push(extra)
+        return { ctx: {}, args: {} }
+      }
+    })
+    const definition = builder(() => 1)
+    expect(await definition.handler({}, {})).toBe(1)
+    expect(options).toEqual([{}])
+  })
+
+  it('honors validators and custom options attached to the function', async () => {
+    const { customFnBuilder } = await import('../src/internal/functions/customFunctions')
+    const options: unknown[] = []
+    const builder = customFnBuilder(capture, {
+      args: {},
+      input: (_ctx, _args, extra) => {
+        options.push(extra)
+        return { ctx: {}, args: {} }
+      }
+    })
+    const at = z.codec(z.string(), z.date(), {
+      decode: value => new Date(value),
+      encode: value => value.toISOString()
+    })
+    const definition = builder(
+      Object.assign((_ctx: unknown, args: { at: Date }) => args.at, {
+        args: z.object({ at }),
+        returns: at,
+        skipConvexValidation: true,
+        label: 'attached'
+      })
+    )
+    const wire = '2026-01-01T00:00:00.000Z'
+    expect(await definition.handler({}, { at: wire })).toBe(wire)
+    expect(options).toEqual([{ skipConvexValidation: true, label: 'attached' }])
+  })
+})

--- a/packages/zodvex/src/internal/customization.ts
+++ b/packages/zodvex/src/internal/customization.ts
@@ -1,6 +1,19 @@
-import type { GenericDatabaseReader, GenericDatabaseWriter } from 'convex/server'
+import type {
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+  GenericDataModel,
+  GenericMutationCtx,
+  GenericQueryCtx
+} from 'convex/server'
 import { ZodvexDatabaseReader, ZodvexDatabaseWriter } from './db'
 import type { ZodTableMap } from './schema'
+
+// Standalone callers historically use the database wrapper's default decoded
+// document map. initZodvex supplies its schema-derived map explicitly.
+type DefaultDecodedDocs =
+  ZodvexDatabaseReader<GenericDataModel> extends ZodvexDatabaseReader<GenericDataModel, infer Docs>
+    ? Docs
+    : never
 
 /**
  * Resolvers for the database the codec wrapper delegates to (#92).
@@ -49,27 +62,51 @@ export type ZodvexUnderlyingDb<
  * })
  * ```
  */
-export function createZodvexCustomization(
+export function createZodvexCustomization<
+  DM extends GenericDataModel = GenericDataModel,
+  DD extends Record<string, unknown> = DefaultDecodedDocs
+>(
   tableMap: ZodTableMap,
-  options?: { underlyingDb?: ZodvexUnderlyingDb }
+  options?: {
+    underlyingDb?: ZodvexUnderlyingDb<
+      GenericQueryCtx<DM>,
+      GenericMutationCtx<DM>,
+      GenericDatabaseReader<DM>,
+      GenericDatabaseWriter<DM>
+    >
+  }
 ) {
   const resolveReaderDb = options?.underlyingDb?.query
   const resolveWriterDb = options?.underlyingDb?.mutation
   return {
     query: {
       args: {} as Record<string, never>,
-      input: async (ctx: any, _args: any, _extra?: any) => ({
+      input: async (
+        ctx: GenericQueryCtx<DM>,
+        _args: Record<string, never>,
+        _extra?: Record<string, unknown>
+      ) => ({
         ctx: {
-          db: new ZodvexDatabaseReader(resolveReaderDb ? resolveReaderDb(ctx) : ctx.db, tableMap)
+          db: new ZodvexDatabaseReader<DM, DD>(
+            resolveReaderDb ? resolveReaderDb(ctx) : ctx.db,
+            tableMap
+          )
         },
         args: {}
       })
     },
     mutation: {
       args: {} as Record<string, never>,
-      input: async (ctx: any, _args: any, _extra?: any) => ({
+      input: async (
+        ctx: GenericMutationCtx<DM>,
+        _args: Record<string, never>,
+        _extra?: Record<string, unknown>
+      ) => ({
         ctx: {
-          db: new ZodvexDatabaseWriter(resolveWriterDb ? resolveWriterDb(ctx) : ctx.db, tableMap)
+          db: new ZodvexDatabaseWriter<DM, DD>(
+            resolveWriterDb ? resolveWriterDb(ctx) : ctx.db,
+            tableMap
+          )
         },
         args: {}
       })

--- a/packages/zodvex/src/internal/functions/contracts.ts
+++ b/packages/zodvex/src/internal/functions/contracts.ts
@@ -5,6 +5,7 @@ import { assertNoNativeZodDate } from '../schema/dateGuards'
 import { handleZodValidationError, validateReturns } from '../serverUtils'
 import { pick } from '../shared/object'
 import { stripUndefined } from '../stripUndefined'
+import type { Overwrite } from '../types'
 import {
   $ZodCustom,
   $ZodDefault,
@@ -20,15 +21,25 @@ import {
 export type FunctionSchemaInput = $ZodType | Record<string, $ZodType> | undefined
 export type DirectFunctionInput = $ZodType | Record<string, $ZodType>
 
-export type CustomInputResult = {
+export type CustomInputResult<Ctx = unknown> = {
   ctx?: Record<string, unknown>
   args?: Record<string, unknown>
-  onSuccess?: (params: { ctx: unknown; args: unknown; result: unknown }) => unknown
+  onSuccess?: (params: { ctx: Ctx; args: Record<string, unknown>; result: unknown }) => unknown
 }
 
-export function normalizeFunctionSchema(input: FunctionSchemaInput): $ZodType | undefined {
-  if (!input) return undefined
-  return input instanceof $ZodType ? input : z.object(input)
+type NormalizedFunctionSchema<S extends FunctionSchemaInput> = S extends $ZodType
+  ? S
+  : S extends Record<string, $ZodType>
+    ? z.ZodObject<S> // zod-ok: raw shapes are constructed using full Zod
+    : undefined
+
+export function normalizeFunctionSchema<S extends FunctionSchemaInput>(
+  input: S
+): NormalizedFunctionSchema<S> {
+  const normalized = !input ? undefined : input instanceof $ZodType ? input : z.object(input)
+  // The runtime branches exactly match the conditional type. TypeScript cannot
+  // narrow the generic S itself when narrowing its value with instanceof.
+  return normalized as NormalizedFunctionSchema<S>
 }
 
 function normalizeFunctionMetaArgs(input: FunctionSchemaInput): z.ZodObject<any> | undefined {
@@ -108,26 +119,38 @@ export function normalizeDirectFunctionInput(input: DirectFunctionInput): {
   }
 }
 
-export function normalizeCustomArgsValidator(args: ZodValidator | $ZodObject): {
-  argsValidator: ZodValidator
-  argsSchema: $ZodObject
-} {
+type NormalizedCustomArgs<S extends ZodValidator | $ZodObject> = S extends $ZodObject
+  ? { argsValidator: S['_zod']['def']['shape']; argsSchema: S }
+  : S extends ZodValidator
+    ? { argsValidator: S; argsSchema: z.ZodObject<S> } // zod-ok: raw shape construction
+    : never
+
+export function normalizeCustomArgsValidator<S extends ZodValidator | $ZodObject>(
+  args: S
+): NormalizedCustomArgs<S> {
+  let normalized: { argsValidator: ZodValidator; argsSchema: $ZodObject }
   if (args instanceof $ZodType) {
     if (args instanceof $ZodObject) {
-      return {
-        argsSchema: args as unknown as $ZodObject,
-        argsValidator: args._zod.def.shape as any
+      normalized = {
+        argsSchema: args,
+        argsValidator: args._zod.def.shape
       }
+    } else {
+      throw new Error(
+        'Unsupported non-object Zod schema for args; please provide an args schema using z.object({...}), e.g. z.object({ foo: z.string() })'
+      )
     }
-    throw new Error(
-      'Unsupported non-object Zod schema for args; please provide an args schema using z.object({...}), e.g. z.object({ foo: z.string() })'
-    )
+  } else {
+    const shape: ZodValidator = args
+    normalized = {
+      argsValidator: shape,
+      argsSchema: z.object(shape)
+    }
   }
-
-  return {
-    argsValidator: args,
-    argsSchema: z.object(args)
-  }
+  // Objects retain their original identity/configuration; raw shapes become
+  // full Zod objects. This assertion connects those checked runtime branches
+  // to S, which instanceof does not narrow at the generic type level.
+  return normalized as NormalizedCustomArgs<S>
 }
 
 export function createConvexReturnsValidator(
@@ -169,46 +192,109 @@ export function parseObjectArgsOrThrow<S extends $ZodObject>(
   return parsed.data
 }
 
-export async function runCustomizationInput(
-  customInput: (ctx: unknown, args: unknown, extra?: unknown) => unknown,
-  ctx: unknown,
+export async function runCustomizationInput<
+  Ctx,
+  Args,
+  Extra,
+  Result extends CustomInputResult<Ctx> | undefined
+>(
+  customInput: (ctx: Ctx, args: Args, extra: Extra) => Result | Promise<Result>,
+  ctx: Ctx,
   allArgs: Record<string, unknown>,
   inputArgs: Record<string, unknown>,
-  extra: Record<string, unknown>,
+  extra: Extra,
   argsSchema?: $ZodObject
-): Promise<CustomInputResult | undefined> {
-  // Cast justification: customInput expects ObjectType<CustomArgsValidator>, but pick()
-  // returns Partial<T>. The cast is safe because inputArgs keys are derived from
-  // CustomArgsValidator at the type level.
-  const picked = pick(allArgs, Object.keys(inputArgs)) as Record<string, unknown>
+): Promise<Result> {
+  const picked = pick(allArgs, Object.keys(inputArgs))
   // #72: when the customization declared its args as zod, decode them (codec
   // transforms applied) before the customization's `input` runs — symmetric
   // with how consumer args are decoded via parseObjectArgsOrThrow.
   const customArgs = argsSchema ? parseObjectArgsOrThrow(argsSchema, picked) : picked
-  return (await customInput(ctx, customArgs as any, extra)) as CustomInputResult | undefined
+  // inputArgs selects the customization's declared keys. Zod declarations are
+  // parsed here; legacy declarations were validated by Convex at registration.
+  // This is the wire-to-decoded boundary whose Args type the caller supplies.
+  return await customInput(ctx, customArgs as Args, extra)
 }
 
-export function applyCustomizationResult(
-  ctx: Record<string, unknown>,
-  baseArgs: Record<string, unknown>,
-  added?: CustomInputResult
-): { finalCtx: Record<string, unknown>; finalArgs: Record<string, unknown> } {
+type RequiredKeys<T> = {
+  // biome-ignore lint/complexity/noBannedTypes: empty-object assignability detects optional keys
+  [K in keyof T]-?: {} extends Pick<T, K> ? never : K
+}[keyof T]
+
+// Optional patch keys may be absent (retaining a base value) or explicitly
+// undefined (overwriting it). Preserve both possibilities and key optionality.
+type SpreadPatch<Base, Patch> = Omit<Base, keyof Patch> &
+  Pick<Patch, RequiredKeys<Patch>> & {
+    [K in keyof Base as K extends keyof Patch
+      ? K extends RequiredKeys<Patch>
+        ? never
+        : K
+      : never]: Base[K] | Patch[K & keyof Patch]
+  } & {
+    [K in keyof Patch as K extends keyof Base
+      ? never
+      : K extends RequiredKeys<Patch>
+        ? never
+        : K]?: Patch[K]
+  }
+
+type MergePatch<Base, Patch> =
+  Patch extends Record<string, unknown>
+    ? Patch extends Required<Patch>
+      ? Overwrite<Base, Patch>
+      : SpreadPatch<Base, Patch>
+    : Base
+
+type ResultPatch<Added, Key extends 'ctx' | 'args'> = Added extends undefined
+  ? undefined
+  : Key extends keyof Added
+    ? Added[Key]
+    : undefined
+
+type AddedResult<Input extends unknown[]> = Input extends [infer Added] ? Added : undefined
+
+export function applyCustomizationResult<
+  Ctx extends Record<string, unknown>,
+  Args extends Record<string, unknown>,
+  Input extends [] | [added: Pick<CustomInputResult, 'ctx' | 'args'> | undefined]
+>(
+  ctx: Ctx,
+  baseArgs: Args,
+  ...customization: Input
+): {
+  finalCtx: MergePatch<Ctx, ResultPatch<AddedResult<Input>, 'ctx'>>
+  finalArgs: MergePatch<Args, ResultPatch<AddedResult<Input>, 'args'>>
+} {
+  const added = customization[0]
   const finalCtx = { ...ctx, ...(added?.ctx ?? {}) }
   const addedArgs = added?.args ?? {}
+  // Generic object spread is inferred as intersection by TypeScript, whereas
+  // runtime spread overwrites keys. The mapped types model that operation,
+  // including absent results, absent patches, and optional individual keys.
   return {
     finalCtx,
     finalArgs: { ...baseArgs, ...addedArgs }
+  } as {
+    finalCtx: MergePatch<Ctx, ResultPatch<AddedResult<Input>, 'ctx'>>
+    finalArgs: MergePatch<Args, ResultPatch<AddedResult<Input>, 'args'>>
   }
 }
 
-export async function finalizeFunctionReturn(
+export async function finalizeFunctionReturn<Ctx>(
   result: unknown,
-  options?: {
-    ctx?: Record<string, unknown>
-    args?: Record<string, unknown>
-    added?: CustomInputResult
-    returns?: $ZodType
-  }
+  options?:
+    | {
+        ctx: Ctx
+        args: Record<string, unknown>
+        added?: CustomInputResult<Ctx>
+        returns?: $ZodType
+      }
+    | {
+        ctx?: undefined
+        args?: Record<string, unknown>
+        added?: undefined
+        returns?: $ZodType
+      }
 ): Promise<unknown> {
   if (options?.added?.onSuccess) {
     await options.added.onSuccess({

--- a/packages/zodvex/src/internal/functions/customFunctions.ts
+++ b/packages/zodvex/src/internal/functions/customFunctions.ts
@@ -10,7 +10,7 @@ import {
   type MutationBuilder,
   type QueryBuilder
 } from 'convex/server'
-import { type PropertyValidators } from 'convex/values'
+import { type PropertyValidators, type Validator } from 'convex/values'
 import { type Customization, NoOp } from 'convex-helpers/server/customFunctions'
 import { z } from 'zod'
 import { type ZodValidator, zodToConvexFields } from '../mapping'
@@ -93,8 +93,8 @@ type ArgsForHandlerType<
 > =
   CustomMadeArgs extends Record<string, never>
     ? OneOrZeroArgs
-    : OneOrZeroArgs extends [infer A]
-      ? [Expand<A & CustomMadeArgs>]
+    : OneOrZeroArgs extends [infer A extends Record<string, any>]
+      ? [Expand<Overwrite<A, CustomMadeArgs>>]
       : [CustomMadeArgs]
 
 // Helper type for function registration (from zodV3)
@@ -108,6 +108,47 @@ type Registration<
   : FuncType extends 'mutation'
     ? import('convex/server').RegisteredMutation<Visibility, Args, Output>
     : import('convex/server').RegisteredAction<Visibility, Args, Output>
+
+type CustomFunction<
+  ArgsValidator extends ZodValidator | $ZodObject | void,
+  ReturnsZodValidator extends $ZodType | ZodValidator | void,
+  ReturnValue,
+  InputCtx,
+  CustomCtx extends Record<string, any>,
+  CustomMadeArgs extends Record<string, any>,
+  ExtraArgs extends Record<string, any>
+> =
+  | ({
+      /**
+       * Specify the arguments to the function as a Zod validator.
+       */
+      args?: ArgsValidator
+      handler: (
+        ctx: Overwrite<InputCtx, CustomCtx>,
+        ...args: ArgsForHandlerType<ArgsOutput<ArgsValidator>, CustomMadeArgs>
+      ) => ReturnValue
+      /**
+       * Validates the value returned by the function.
+       * Note: you can't pass an object directly without wrapping it
+       * in `z.object()`.
+       */
+      returns?: ReturnsZodValidator
+      /**
+       * If true, the function will not be validated by Convex,
+       * in case you're seeing performance issues with validating twice.
+       */
+      skipConvexValidation?: boolean
+    } & {
+      [key in keyof ExtraArgs as key extends 'args' | 'handler' | 'skipConvexValidation' | 'returns'
+        ? never
+        : key]: ExtraArgs[key]
+    })
+  | {
+      (
+        ctx: Overwrite<InputCtx, CustomCtx>,
+        ...args: ArgsForHandlerType<ArgsOutput<ArgsValidator>, CustomMadeArgs>
+      ): ReturnValue
+    }
 
 /**
  * A builder that customizes a Convex function, whether or not it validates
@@ -134,42 +175,15 @@ export type CustomBuilder<
     ReturnsZodValidator extends $ZodType | ZodValidator | void = void,
     ReturnValue extends ReturnValueInput<ReturnsZodValidator> = any
   >(
-    func:
-      | ({
-          /**
-           * Specify the arguments to the function as a Zod validator.
-           */
-          args?: ArgsValidator
-          handler: (
-            ctx: Overwrite<InputCtx, CustomCtx>,
-            ...args: ArgsForHandlerType<ArgsOutput<ArgsValidator>, CustomMadeArgs>
-          ) => ReturnValue
-          /**
-           * Validates the value returned by the function.
-           * Note: you can't pass an object directly without wrapping it
-           * in `z.object()`.
-           */
-          returns?: ReturnsZodValidator
-          /**
-           * If true, the function will not be validated by Convex,
-           * in case you're seeing performance issues with validating twice.
-           */
-          skipConvexValidation?: boolean
-        } & {
-          [key in keyof ExtraArgs as key extends
-            | 'args'
-            | 'handler'
-            | 'skipConvexValidation'
-            | 'returns'
-            ? never
-            : key]: ExtraArgs[key]
-        })
-      | {
-          (
-            ctx: Overwrite<InputCtx, CustomCtx>,
-            ...args: ArgsForHandlerType<ArgsOutput<ArgsValidator>, CustomMadeArgs>
-          ): ReturnValue
-        }
+    func: CustomFunction<
+      ArgsValidator,
+      ReturnsZodValidator,
+      ReturnValue,
+      InputCtx,
+      CustomCtx,
+      CustomMadeArgs,
+      ExtraArgs
+    >
   ): Registration<
     FuncType,
     Visibility,
@@ -184,16 +198,42 @@ export type CustomBuilder<
   >
 }
 
+function isZodArgs(args: Record<string, unknown>): args is ZodValidator {
+  const values = Object.values(args)
+  return values.length > 0 && values.every(value => value instanceof $ZodType)
+}
+
+type NativeFunction<Ctx> = {
+  args: PropertyValidators
+  returns?: Validator<any>
+  handler: (ctx: Ctx, args: Record<string, unknown>) => Promise<unknown>
+}
+
+type BuilderCtx<Builder> =
+  Builder extends QueryBuilder<infer DM, FunctionVisibility>
+    ? GenericQueryCtx<DM>
+    : Builder extends MutationBuilder<infer DM, FunctionVisibility>
+      ? GenericMutationCtx<DM>
+      : Builder extends ActionBuilder<infer DM, FunctionVisibility>
+        ? GenericActionCtx<DM>
+        : Record<string, unknown>
+
 export function customFnBuilder<
-  Ctx extends Record<string, any>,
-  Builder extends (fn: any) => any,
+  Builder extends (fn: any) => object,
   CustomArgsValidator extends PropertyValidators,
   CustomCtx extends Record<string, any>,
   CustomMadeArgs extends Record<string, any>,
-  ExtraArgs extends Record<string, any> = Record<string, any>
+  ExtraArgs extends Record<string, any> = Record<string, any>,
+  Ctx extends Record<string, any> = BuilderCtx<Builder>
 >(
   builder: Builder,
-  customization: Customization<Ctx, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
+  customization: Customization<
+    NoInfer<Ctx>,
+    CustomArgsValidator,
+    CustomCtx,
+    CustomMadeArgs,
+    ExtraArgs
+  >
 ) {
   const customInput = customization.input ?? NoOp.input
   const rawInputArgs = customization.args ?? NoOp.args
@@ -203,93 +243,92 @@ export function customFnBuilder<
   // pipeline as consumer args — converted to Convex validators for registration
   // and codec-decoded before `input` runs. Pre-built Convex validators (the
   // legacy shape) are passed through unchanged for back-compat.
-  const customArgEntries = Object.entries(rawInputArgs)
-  const customArgsAreZod =
-    customArgEntries.length > 0 && customArgEntries.every(([, v]) => v instanceof $ZodType)
-  const inputArgs = customArgsAreZod
-    ? zodToConvexFields(rawInputArgs as unknown as ZodValidator)
-    : rawInputArgs
-  const customArgsSchema = customArgsAreZod
-    ? (z.object(rawInputArgs as any) as unknown as $ZodObject)
-    : undefined
+  const customArgsAreZod = isZodArgs(rawInputArgs)
+  const inputArgs = customArgsAreZod ? zodToConvexFields(rawInputArgs) : rawInputArgs
+  const customArgsSchema = customArgsAreZod ? z.object(rawInputArgs) : undefined
 
-  return function customBuilder(fn: any): any {
-    const { args, handler = fn, returns: maybeObject, ...extra } = fn
-    const skipConvexValidation = fn.skipConvexValidation ?? false
+  return function customBuilder<
+    ArgsValidator extends ZodValidator | $ZodObject | void,
+    ReturnsValidator extends $ZodType | ZodValidator | void = void,
+    Result extends ReturnValueInput<ReturnsValidator> = any
+  >(
+    fn: CustomFunction<
+      ArgsValidator,
+      ReturnsValidator,
+      Result,
+      Ctx,
+      CustomCtx,
+      CustomMadeArgs,
+      ExtraArgs
+    >
+  ) {
+    type Properties = Exclude<typeof fn, (...args: any[]) => unknown>
+    // Shorthand functions may carry validators/options as own properties.
+    // Read the original object so enumerable custom options survive unchanged.
+    const properties = fn as typeof fn & Partial<Properties>
+    const { args, handler: attachedHandler, returns: maybeObject, ...extra } = properties
+    const handler = attachedHandler ?? (typeof fn === 'function' ? fn : fn.handler)
+    const skipConvexValidation = properties.skipConvexValidation ?? false
 
-    const returns = normalizeFunctionSchema(maybeObject)
+    const returns = normalizeFunctionSchema(maybeObject || undefined)
     const returnValidator = createConvexReturnsValidator(returns, { skipConvexValidation })
     const convexReturns = returnValidator ? { returns: returnValidator } : undefined
 
     // Check for z.date() usage at construction time (once), not on every invocation
     if (returns) {
-      assertNoNativeZodDate(returns as $ZodType, 'returns')
+      assertNoNativeZodDate(returns, 'returns')
     }
 
-    if (args) {
-      const { argsValidator, argsSchema } = normalizeCustomArgsValidator(args)
+    const normalizedArgs = args ? normalizeCustomArgsValidator(args) : undefined
+    if (normalizedArgs) assertNoNativeZodDate(normalizedArgs.argsSchema, 'args')
+    const convexArgs =
+      normalizedArgs && !skipConvexValidation
+        ? { ...zodToConvexFields(normalizedArgs.argsValidator), ...inputArgs }
+        : inputArgs
 
-      // Only generate Convex args validator when not skipping Convex validation
-      const convexArgs = skipConvexValidation
-        ? inputArgs
-        : { ...zodToConvexFields(argsValidator), ...inputArgs }
-
-      // Check for z.date() usage at construction time (once), not on every invocation
-      assertNoNativeZodDate(argsSchema, 'args')
-
-      const registered = builder({
-        args: convexArgs,
-        ...convexReturns,
-        handler: async (ctx: Ctx, allArgs: any) => {
-          const added = await runCustomizationInput(
-            customInput as any,
-            ctx,
-            allArgs,
-            inputArgs,
-            extra,
-            customArgsSchema
-          )
-          const argKeys = Object.keys(argsValidator)
-          const rawArgs = pick(allArgs, argKeys)
-          const baseArgs = parseObjectArgsOrThrow(argsSchema, rawArgs)
-          const { finalCtx, finalArgs } = applyCustomizationResult(ctx as any, baseArgs, added)
-
-          const ret = await handler(finalCtx, finalArgs)
-          return finalizeFunctionReturn(ret, { ctx: ctx as any, args: baseArgs, added, returns })
-        }
-      })
-      // Merge via shape-spread rather than .extend() — `argsSchema` may be a
-      // user-supplied zod/mini object, which has no schema methods. Custom args
-      // win on key conflicts, mirroring the `convexArgs` spread above.
-      const metaArgsSchema = customArgsSchema
-        ? (z.object({
-            ...(argsSchema as any)._zod.def.shape,
-            ...(customArgsSchema as any)._zod.def.shape
-          }) as unknown as $ZodObject)
-        : argsSchema
-      attachFunctionMeta(registered, metaArgsSchema, returns)
-      return registered
-    }
-    const registered = builder({
-      args: inputArgs,
+    const nativeDefinition: NativeFunction<Ctx> = {
+      args: convexArgs,
       ...convexReturns,
-      handler: async (ctx: Ctx, allArgs: any) => {
-        const baseArgs = allArgs as Record<string, unknown>
+      handler: async (ctx: Ctx, allArgs: Record<string, unknown>) => {
         const added = await runCustomizationInput(
-          customInput as any,
+          customInput,
           ctx,
           allArgs,
           inputArgs,
-          extra,
+          // Reserved function fields are removed before forwarding customization options.
+          // Plain shorthand forwards an empty options object.
+          extra as unknown as ExtraArgs,
           customArgsSchema
         )
-        const { finalCtx, finalArgs } = applyCustomizationResult(ctx as any, baseArgs, added)
-
-        const ret = await handler(finalCtx, finalArgs)
-        return finalizeFunctionReturn(ret, { ctx: ctx as any, args: baseArgs, added, returns })
+        const baseArgs = normalizedArgs
+          ? parseObjectArgsOrThrow(
+              normalizedArgs.argsSchema,
+              pick(allArgs, Object.keys(normalizedArgs.argsValidator))
+            )
+          : allArgs
+        const { finalCtx, finalArgs } = applyCustomizationResult(ctx, baseArgs, added)
+        // Runtime selection/decoding and object spread implement these public
+        // conditional types, which TS cannot narrow using the optional args branch.
+        const ret = await handler(
+          finalCtx as Overwrite<Ctx, CustomCtx>,
+          ...([finalArgs] as ArgsForHandlerType<ArgsOutput<ArgsValidator>, CustomMadeArgs>)
+        )
+        return finalizeFunctionReturn(ret, { ctx, args: baseArgs, added, returns })
       }
-    })
-    attachFunctionMeta(registered, customArgsSchema ?? undefined, returns)
+    }
+    // Convex's generic call signature cannot retain its instantiated return
+    // through a generic factory; keep the actual registered object's type.
+    const registered = builder(nativeDefinition) as ReturnType<Builder>
+    // Mini objects have no .extend(); custom schemas win metadata key conflicts.
+    const metaArgsSchema = normalizedArgs
+      ? customArgsSchema
+        ? z.object({
+            ...normalizedArgs.argsSchema._zod.def.shape,
+            ...customArgsSchema._zod.def.shape
+          })
+        : normalizedArgs.argsSchema
+      : customArgsSchema
+    attachFunctionMeta(registered, metaArgsSchema, returns)
     return registered
   }
 }
@@ -347,7 +386,6 @@ export function zCustomQuery<
   customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
 ) {
   return customFnBuilder<
-    any,
     QueryBuilder<any, Visibility>,
     CustomArgsValidator,
     CustomCtx,
@@ -389,7 +427,7 @@ export function zCustomMutation<
   mutation: Builder,
   customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
 ) {
-  return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
+  return customFnBuilder<Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
     mutation,
     customization
   )
@@ -428,7 +466,7 @@ export function zCustomAction<
   action: Builder,
   customization: Customization<any, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>
 ) {
-  return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
+  return customFnBuilder<Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
     action,
     customization
   )

--- a/packages/zodvex/src/internal/functions/init.ts
+++ b/packages/zodvex/src/internal/functions/init.ts
@@ -17,8 +17,9 @@ import { createZodvexCustomization, type ZodvexUnderlyingDb } from '../customiza
 import type { ZodvexDatabaseReader, ZodvexDatabaseWriter } from '../db'
 import type { ZodValidator } from '../mapping'
 import type { ZodTableMap } from '../schema'
-import type { AnyRegistry, Overwrite } from '../types'
+import type { AnyRegistry, ExtractCtx, Overwrite } from '../types'
 import type { $ZodObject } from '../zod-core'
+import { applyCustomizationResult } from './contracts'
 import type { CustomBuilder } from './customFunctions'
 import { zCustomAction, zCustomMutation, zCustomQuery } from './customFunctions'
 
@@ -57,18 +58,29 @@ export type ZodvexActionCtx<DM extends GenericDataModel> = GenericActionCtx<DM>
 // biome-ignore lint/complexity/noBannedTypes: {} is semantically correct here — see comment above
 type NoCodecCtx = {}
 
-type InternalCustomization = {
+type InternalCustomization<
+  Ctx extends object = Record<string, unknown>,
+  Patch extends Record<string, unknown> = Record<string, unknown>,
+  Extra extends Record<string, unknown> = Record<string, unknown>
+> = {
   args: Record<string, never>
-  input: (ctx: any, args: any, extra?: any) => any
+  input: (
+    ctx: Ctx,
+    args: Record<string, never>,
+    extra?: Extra
+  ) => MaybePromise<{
+    ctx: Patch
+    args: Record<string, never>
+  }>
 }
 
-type InitServerBuilders = {
-  query: QueryBuilder<any, 'public'>
-  mutation: MutationBuilder<any, 'public'>
-  action: ActionBuilder<any, 'public'>
-  internalQuery: QueryBuilder<any, 'internal'>
-  internalMutation: MutationBuilder<any, 'internal'>
-  internalAction: ActionBuilder<any, 'internal'>
+type InitServerBuilders<DM extends GenericDataModel> = {
+  query: QueryBuilder<DM, 'public'>
+  mutation: MutationBuilder<DM, 'public'>
+  action: ActionBuilder<DM, 'public'>
+  internalQuery: QueryBuilder<DM, 'internal'>
+  internalMutation: MutationBuilder<DM, 'internal'>
+  internalAction: ActionBuilder<DM, 'internal'>
 }
 
 type MaybePromise<T> = T | Promise<T>
@@ -297,13 +309,18 @@ export function initZodvex<
 }
 
 // Implementation
-export function initZodvex(
-  schema: { __zodTableMap: ZodTableMap },
-  server: InitServerBuilders,
+export function initZodvex<DM extends GenericDataModel, DD extends Record<string, unknown>>(
+  schema: { __zodTableMap: ZodTableMap; __decodedDocs?: DD },
+  server: InitServerBuilders<DM>,
   options?: {
     wrapDb?: boolean
     registry?: () => AnyRegistry
-    underlyingDb?: ZodvexUnderlyingDb
+    underlyingDb?: ZodvexUnderlyingDb<
+      GenericQueryCtx<DM>,
+      GenericMutationCtx<DM>,
+      GenericDatabaseReader<DM>,
+      GenericDatabaseWriter<DM>
+    >
   }
 ) {
   const wrap = options?.wrapDb !== false
@@ -313,44 +330,48 @@ export function initZodvex(
         'remove `wrapDb: false` or drop `underlyingDb`.'
     )
   }
-  const codec = createZodvexCustomization(schema.__zodTableMap, {
+  const codec = createZodvexCustomization<DM, DD>(schema.__zodTableMap, {
     underlyingDb: options?.underlyingDb
   })
   const noOp = createNoOpCustomization()
 
   const registryThunk = options?.registry
-  const actionCust = createActionCustomization(registryThunk, noOp)
-  const customizations = {
-    query: wrap ? codec.query : noOp,
-    mutation: createMutationCustomization(wrap ? codec.mutation : noOp, registryThunk),
-    action: actionCust
+  const actionCust = createActionCustomization<DM>(registryThunk, noOp)
+  function createBuilders<
+    QueryPatch extends Record<string, unknown>,
+    MutationPatch extends Record<string, unknown>
+  >(
+    queryCust: InternalCustomization<GenericQueryCtx<DM>, QueryPatch>,
+    mutationDbCust: InternalCustomization<GenericMutationCtx<DM>, MutationPatch>
+  ) {
+    const mutationCust = createMutationCustomization(mutationDbCust, registryThunk)
+    return {
+      zq: createZodvexBuilder(server.query, queryCust, zCustomQuery),
+      zm: createZodvexBuilder(server.mutation, mutationCust, zCustomMutation),
+      za: createZodvexBuilder(server.action, actionCust, zCustomAction),
+      ziq: createZodvexBuilder(server.internalQuery, queryCust, zCustomQuery),
+      zim: createZodvexBuilder(server.internalMutation, mutationCust, zCustomMutation),
+      zia: createZodvexBuilder(server.internalAction, actionCust, zCustomAction)
+    }
   }
-
-  return {
-    zq: createZodvexBuilder(server.query, customizations.query, zCustomQuery),
-    zm: createZodvexBuilder(server.mutation, customizations.mutation, zCustomMutation),
-    za: createZodvexBuilder(server.action, customizations.action, zCustomAction),
-    ziq: createZodvexBuilder(server.internalQuery, customizations.query, zCustomQuery),
-    zim: createZodvexBuilder(server.internalMutation, customizations.mutation, zCustomMutation),
-    zia: createZodvexBuilder(server.internalAction, customizations.action, zCustomAction)
-  }
+  return wrap ? createBuilders(codec.query, codec.mutation) : createBuilders(noOp, noOp)
 }
 
-function createNoOpCustomization(): InternalCustomization {
+function createNoOpCustomization(): InternalCustomization<object, NoCodecCtx> {
   return { args: {} as Record<string, never>, input: NoOp.input }
 }
 
-function createActionCustomization(
+function createActionCustomization<DM extends GenericDataModel>(
   registryThunk: (() => AnyRegistry) | undefined,
-  noOp: InternalCustomization
-): InternalCustomization {
+  noOp: InternalCustomization<object, NoCodecCtx>
+): InternalCustomization<GenericActionCtx<DM>, NoCodecCtx> {
   if (!registryThunk) {
     return noOp
   }
 
   return {
     args: {} as Record<string, never>,
-    input: async (ctx: any) => ({
+    input: async (ctx: GenericActionCtx<DM>) => ({
       // Auto-encode codec args at outbound call sites: runQuery/runMutation
       // (encode args, decode result) and scheduler.runAfter/runAt (encode args).
       ctx: createCodecCallOverrides(registryThunk(), ctx),
@@ -367,17 +388,24 @@ function createActionCustomization(
  *
  * Without a registry, the DB customization is returned unchanged.
  */
-function createMutationCustomization(
-  dbCust: InternalCustomization,
+function createMutationCustomization<
+  DM extends GenericDataModel,
+  Patch extends Record<string, unknown>
+>(
+  dbCust: InternalCustomization<GenericMutationCtx<DM>, Patch>,
   registryThunk: (() => AnyRegistry) | undefined
-): InternalCustomization {
+): InternalCustomization<GenericMutationCtx<DM>, Patch> {
   if (!registryThunk) {
     return dbCust
   }
 
   return {
     args: {} as Record<string, never>,
-    input: async (ctx: any, _args: any, extra?: any) => {
+    input: async (
+      ctx: GenericMutationCtx<DM>,
+      _args: Record<string, never>,
+      extra?: Record<string, unknown>
+    ) => {
       const dbResult = await dbCust.input(ctx, {}, extra)
       const callOverrides = createCodecCallOverrides(registryThunk(), ctx)
       return {
@@ -398,16 +426,25 @@ function createMutationCustomization(
  *
  * @internal Exported for testing only -- not part of the public API.
  */
-export function composeCustomizations(
-  codecCust: InternalCustomization,
-  userCust: { args?: any; input?: (ctx: any, args: any, extra?: any) => any }
+export function composeCustomizations<
+  Ctx extends object,
+  CodecCtx extends Record<string, unknown>,
+  ZArgs extends ZodValidator = Record<string, never>,
+  CustomCtx extends Record<string, unknown> = Record<string, never>,
+  MadeArgs extends Record<string, unknown> = Record<string, never>,
+  Extra extends Record<string, unknown> = Record<string, unknown>
+>(
+  codecCust: InternalCustomization<Ctx, CodecCtx, Extra>,
+  userCust: ZodvexCustomization<Overwrite<Ctx, CodecCtx>, ZArgs, CustomCtx, MadeArgs, Extra>
 ) {
   return {
     args: userCust.args ?? {},
-    input: async (ctx: any, args: any, extra?: any) => {
+    input: async (ctx: Ctx, args: ResolvedCustomArgs<ZArgs>, extra?: Extra) => {
       // 1. Codec layer: wrap ctx.db
       const codecResult = await codecCust.input(ctx, {}, extra)
-      const codecCtx = { ...ctx, ...codecResult.ctx }
+      // The public builder contract models context patches with Overwrite.
+      // Generic object spread otherwise infers an incompatible intersection.
+      const codecCtx = { ...ctx, ...codecResult.ctx } as Overwrite<Ctx, CodecCtx>
 
       // 2. User layer: sees codec-wrapped ctx.db
       if (!userCust.input) {
@@ -416,9 +453,10 @@ export function composeCustomizations(
       const userResult = await userCust.input(codecCtx, args, extra)
 
       // 3. Merge ctx/args; pass through user's onSuccess (convex-helpers convention)
+      const merged = applyCustomizationResult(codecResult.ctx, {}, userResult)
       return {
-        ctx: { ...codecResult.ctx, ...(userResult.ctx ?? {}) },
-        args: userResult.args ?? {},
+        ctx: merged.finalCtx,
+        args: merged.finalArgs,
         ...(userResult.onSuccess && { onSuccess: userResult.onSuccess })
       }
     }
@@ -435,17 +473,73 @@ export function composeCustomizations(
  *
  * @internal Exported for testing only -- not part of the public API.
  */
-export function createZodvexBuilder(
-  rawBuilder: any,
-  codecCust: InternalCustomization,
-  customFn: (builder: any, customization: any) => any
-) {
-  const base: any = customFn(rawBuilder, codecCust)
+type BuilderCtx<B> = ExtractCtx<B> extends object ? ExtractCtx<B> : never
+type FactoryFor<B extends (definition: never) => object> =
+  ReturnType<B> extends { isQuery: true }
+    ? typeof zCustomQuery
+    : ReturnType<B> extends { isMutation: true }
+      ? typeof zCustomMutation
+      : typeof zCustomAction
 
-  base.withContext = (userCust: any) => {
+export function createZodvexBuilder<
+  Builder extends (definition: never) => object,
+  CodecCtx extends Record<string, unknown>
+>(
+  rawBuilder: Builder,
+  codecCust: InternalCustomization<BuilderCtx<Builder>, CodecCtx>,
+  customFn: FactoryFor<NoInfer<Builder>>
+) {
+  type Ctx = BuilderCtx<Builder>
+  type Kind =
+    ReturnType<Builder> extends { isQuery: true }
+      ? 'query'
+      : ReturnType<Builder> extends { isMutation: true }
+        ? 'mutation'
+        : 'action'
+  type Visibility = ReturnType<Builder> extends { isInternal: true } ? 'internal' : 'public'
+  // These legacy entry points type declared args as Convex validators even
+  // though their shared implementation also accepts Zod shapes. Retain their
+  // known registration contract at this one schema-language boundary.
+  const registerBase = customFn as unknown as (
+    builder: Builder,
+    customization: InternalCustomization<Ctx, CodecCtx>
+  ) => CustomBuilder<
+    Kind,
+    Record<string, never>,
+    CodecCtx,
+    Record<string, never>,
+    Ctx,
+    Visibility,
+    Record<string, unknown>
+  >
+  const base = registerBase(rawBuilder, codecCust)
+
+  const withContext = <
+    ZArgs extends ZodValidator = Record<string, never>,
+    CustomCtx extends Record<string, unknown> = Record<string, never>,
+    MadeArgs extends Record<string, unknown> = Record<string, never>,
+    Extra extends Record<string, unknown> = Record<string, unknown>
+  >(
+    userCust: ZodvexCustomization<Overwrite<Ctx, CodecCtx>, ZArgs, CustomCtx, MadeArgs, Extra>
+  ) => {
     const composed = composeCustomizations(codecCust, userCust)
-    return customFn(rawBuilder, composed)
+    // zCustom* still expose Convex-only customization declarations for legacy
+    // callers. Their runtime also handles Zod declarations; this adapter keeps
+    // that schema-language boundary local while retaining decoded argument types.
+    const register = customFn as unknown as (
+      builder: Builder,
+      customization: typeof composed
+    ) => CustomBuilder<
+      Kind,
+      ResolvedCustomArgs<ZArgs>,
+      Overwrite<CodecCtx, CustomCtx>,
+      MadeArgs,
+      Ctx,
+      Visibility,
+      Extra
+    >
+    return register(rawBuilder, composed)
   }
 
-  return base
+  return Object.assign(base, { withContext })
 }

--- a/packages/zodvex/src/internal/legacy/builders.ts
+++ b/packages/zodvex/src/internal/legacy/builders.ts
@@ -190,7 +190,7 @@ export function zCustomQueryBuilder<
   Visibility,
   ExtraArgs
 > {
-  return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
+  return customFnBuilder<Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs, any>(
     query,
     customization
   )
@@ -245,7 +245,7 @@ export function zCustomMutationBuilder<
   Visibility,
   ExtraArgs
 > {
-  return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
+  return customFnBuilder<Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs, any>(
     mutation,
     customization
   )
@@ -301,7 +301,7 @@ export function zCustomActionBuilder<
   Visibility,
   ExtraArgs
 > {
-  return customFnBuilder<any, Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs>(
+  return customFnBuilder<Builder, CustomArgsValidator, CustomCtx, CustomMadeArgs, ExtraArgs, any>(
     action,
     customization
   )

--- a/packages/zodvex/typechecks/builder-implementation.test-d.ts
+++ b/packages/zodvex/typechecks/builder-implementation.test-d.ts
@@ -1,0 +1,46 @@
+import { queryGeneric } from 'convex/server'
+import { NoOp } from 'convex-helpers/server/customFunctions'
+import { z } from 'zod'
+import {
+  customFnBuilder,
+  zCustomAction,
+  zCustomMutation
+} from '../src/internal/functions/customFunctions'
+import type { Equal, Expect } from './test-helpers'
+
+const query = customFnBuilder(queryGeneric, NoOp)
+query({
+  args: z.object({
+    at: z.codec(z.string(), z.date(), {
+      decode: value => new Date(value),
+      encode: value => value.toISOString()
+    })
+  }),
+  handler: (_ctx, args) => {
+    type _Decoded = Expect<Equal<typeof args.at, Date>>
+    // @ts-expect-error The implementation must preserve decoded args, not accept wire values
+    const _wire: string = args.at
+    // @ts-expect-error The implementation must not invent schema properties
+    args.missing
+    return args.at
+  }
+})
+
+// @ts-expect-error A registration factory must return a registered function, not a primitive
+customFnBuilder(() => 123, NoOp)
+
+query({
+  args: { value: z.number() },
+  returns: z.number(),
+  // @ts-expect-error The implementation must enforce the declared decoded return
+  handler: () => 'wrong'
+})
+query({
+  handler: ctx => {
+    ctx.db.query('anyTable')
+    // @ts-expect-error Query handlers have no mutation writer
+    ctx.db.insert('anyTable', {})
+    // @ts-expect-error Raw query context has no invented property
+    ctx.missing
+  }
+})

--- a/packages/zodvex/typechecks/customization-overwrite.test-d.ts
+++ b/packages/zodvex/typechecks/customization-overwrite.test-d.ts
@@ -1,0 +1,163 @@
+import {
+  actionGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+  mutationGeneric,
+  queryGeneric
+} from 'convex/server'
+import { z } from 'zod'
+import * as mini from 'zod/mini'
+import { initZodvex } from '../src/internal/functions/init'
+import type { Equal, Expect } from './test-helpers'
+
+const builders = initZodvex(
+  { __zodTableMap: {} },
+  {
+    query: queryGeneric,
+    mutation: mutationGeneric,
+    action: actionGeneric,
+    internalQuery: internalQueryGeneric,
+    internalMutation: internalMutationGeneric,
+    internalAction: internalActionGeneric
+  },
+  { wrapDb: false }
+)
+
+{
+  const customized = builders.zq.withContext({
+    input: () => ({ ctx: {}, args: { count: 'replacement' } })
+  })
+  customized({
+    args: z.object({ count: z.number(), retained: z.boolean() }),
+    handler: (_ctx, args) => {
+      type _Count = Expect<Equal<typeof args.count, string>>
+      type _Retained = Expect<Equal<typeof args.retained, boolean>>
+      // @ts-expect-error Customization replaces count rather than intersecting it
+      const _wrong: number = args.count
+      return args.count.toUpperCase()
+    }
+  })
+  customized({
+    args: mini.object({ count: mini.number() }),
+    handler: (_ctx, args) => {
+      type _MiniCount = Expect<Equal<typeof args.count, string>>
+      return args.count.toUpperCase()
+    }
+  })
+}
+
+{
+  const customized = builders.zm.withContext({
+    input: () => ({ ctx: {}, args: { count: 'replacement' } })
+  })
+  customized({
+    args: z.object({ count: z.number(), retained: z.boolean() }),
+    handler: (_ctx, args) => {
+      type _Count = Expect<Equal<typeof args.count, string>>
+      type _Retained = Expect<Equal<typeof args.retained, boolean>>
+      // @ts-expect-error Customization replaces count rather than intersecting it
+      const _wrong: number = args.count
+      return args.count.toUpperCase()
+    }
+  })
+  customized({
+    args: mini.object({ count: mini.number() }),
+    handler: (_ctx, args) => {
+      type _MiniCount = Expect<Equal<typeof args.count, string>>
+      return args.count.toUpperCase()
+    }
+  })
+}
+
+{
+  const customized = builders.za.withContext({
+    input: () => ({ ctx: {}, args: { count: 'replacement' } })
+  })
+  customized({
+    args: z.object({ count: z.number(), retained: z.boolean() }),
+    handler: (_ctx, args) => {
+      type _Count = Expect<Equal<typeof args.count, string>>
+      type _Retained = Expect<Equal<typeof args.retained, boolean>>
+      // @ts-expect-error Customization replaces count rather than intersecting it
+      const _wrong: number = args.count
+      return args.count.toUpperCase()
+    }
+  })
+  customized({
+    args: mini.object({ count: mini.number() }),
+    handler: (_ctx, args) => {
+      type _MiniCount = Expect<Equal<typeof args.count, string>>
+      return args.count.toUpperCase()
+    }
+  })
+}
+
+{
+  const customized = builders.ziq.withContext({
+    input: () => ({ ctx: {}, args: { count: 'replacement' } })
+  })
+  customized({
+    args: z.object({ count: z.number(), retained: z.boolean() }),
+    handler: (_ctx, args) => {
+      type _Count = Expect<Equal<typeof args.count, string>>
+      type _Retained = Expect<Equal<typeof args.retained, boolean>>
+      // @ts-expect-error Customization replaces count rather than intersecting it
+      const _wrong: number = args.count
+      return args.count.toUpperCase()
+    }
+  })
+  customized({
+    args: mini.object({ count: mini.number() }),
+    handler: (_ctx, args) => {
+      type _MiniCount = Expect<Equal<typeof args.count, string>>
+      return args.count.toUpperCase()
+    }
+  })
+}
+
+{
+  const customized = builders.zim.withContext({
+    input: () => ({ ctx: {}, args: { count: 'replacement' } })
+  })
+  customized({
+    args: z.object({ count: z.number(), retained: z.boolean() }),
+    handler: (_ctx, args) => {
+      type _Count = Expect<Equal<typeof args.count, string>>
+      type _Retained = Expect<Equal<typeof args.retained, boolean>>
+      // @ts-expect-error Customization replaces count rather than intersecting it
+      const _wrong: number = args.count
+      return args.count.toUpperCase()
+    }
+  })
+  customized({
+    args: mini.object({ count: mini.number() }),
+    handler: (_ctx, args) => {
+      type _MiniCount = Expect<Equal<typeof args.count, string>>
+      return args.count.toUpperCase()
+    }
+  })
+}
+
+{
+  const customized = builders.zia.withContext({
+    input: () => ({ ctx: {}, args: { count: 'replacement' } })
+  })
+  customized({
+    args: z.object({ count: z.number(), retained: z.boolean() }),
+    handler: (_ctx, args) => {
+      type _Count = Expect<Equal<typeof args.count, string>>
+      type _Retained = Expect<Equal<typeof args.retained, boolean>>
+      // @ts-expect-error Customization replaces count rather than intersecting it
+      const _wrong: number = args.count
+      return args.count.toUpperCase()
+    }
+  })
+  customized({
+    args: mini.object({ count: mini.number() }),
+    handler: (_ctx, args) => {
+      type _MiniCount = Expect<Equal<typeof args.count, string>>
+      return args.count.toUpperCase()
+    }
+  })
+}

--- a/packages/zodvex/typechecks/function-contracts.test-d.ts
+++ b/packages/zodvex/typechecks/function-contracts.test-d.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod'
 import * as mini from 'zod/mini'
-import { parseObjectArgsOrThrow } from '../src/internal/functions/contracts'
+import {
+  applyCustomizationResult,
+  finalizeFunctionReturn,
+  normalizeCustomArgsValidator,
+  normalizeFunctionSchema,
+  parseObjectArgsOrThrow,
+  runCustomizationInput
+} from '../src/internal/functions/contracts'
 import type { Equal, Expect } from './test-helpers'
 
 const at = z.codec(z.string(), z.date(), {
@@ -18,3 +25,81 @@ const small = parseObjectArgsOrThrow(mini.object({ n: mini.number() }), {})
 type _MiniOutput = Expect<Equal<typeof small, { n: number }>>
 // @ts-expect-error Object parser rejects primitive schemas
 parseObjectArgsOrThrow(z.number(), {})
+
+const shape = { at, n: z.number().default(1) }
+const normalizedShape = normalizeCustomArgsValidator(shape)
+type _ShapeValidators = Expect<Equal<typeof normalizedShape.argsValidator, typeof shape>>
+const normalizedOutput = parseObjectArgsOrThrow(normalizedShape.argsSchema, {})
+type _NormalizedOutput = Expect<Equal<typeof normalizedOutput, { at: Date; n: number }>>
+// @ts-expect-error Normalization must not introduce unchecked keys
+normalizedOutput.missing
+
+const strictSchema = z.strictObject(shape)
+const normalizedObject = normalizeCustomArgsValidator(strictSchema)
+type _ObjectIdentity = Expect<Equal<typeof normalizedObject.argsSchema, typeof strictSchema>>
+type _ObjectValidators = Expect<Equal<typeof normalizedObject.argsValidator, typeof shape>>
+const miniSchema = mini.looseObject({ n: mini.number() })
+const normalizedMini = normalizeCustomArgsValidator(miniSchema)
+type _MiniIdentity = Expect<Equal<typeof normalizedMini.argsSchema, typeof miniSchema>>
+type _MiniNormalizedOutput = Expect<
+  Equal<z.output<typeof normalizedMini.argsSchema>, mini.output<typeof miniSchema>>
+>
+
+const normalizedReturn = normalizeFunctionSchema(at)
+type _ReturnIdentity = Expect<Equal<typeof normalizedReturn, typeof at>>
+const normalizedReturnShape = normalizeFunctionSchema(shape)
+type _ReturnShapeOutput = Expect<
+  Equal<z.output<typeof normalizedReturnShape>, { at: Date; n: number }>
+>
+const normalizedMiniReturn = normalizeFunctionSchema(miniSchema)
+type _MiniReturnIdentity = Expect<Equal<typeof normalizedMiniReturn, typeof miniSchema>>
+const absentReturn = normalizeFunctionSchema(undefined)
+type _AbsentReturn = Expect<Equal<typeof absentReturn, undefined>>
+const optionalSchema = null as unknown as typeof strictSchema | undefined
+const normalizedOptional = normalizeFunctionSchema(optionalSchema)
+type _OptionalReturn = Expect<Equal<typeof normalizedOptional, typeof strictSchema | undefined>>
+
+const merged = applyCustomizationResult(
+  { auth: 'original', retained: true },
+  { id: 'wire', retained: 1 },
+  { ctx: { auth: 123 }, args: { id: new Date() } }
+)
+type _MergedContext = Expect<Equal<typeof merged.finalCtx.auth, number>>
+type _MergedArgs = Expect<Equal<typeof merged.finalArgs.id, Date>>
+type _RetainedArgs = Expect<Equal<typeof merged.finalArgs.retained, number>>
+const unmodified = applyCustomizationResult({ auth: 'original' }, { id: 'wire' })
+type _AbsentPatch = Expect<Equal<typeof unmodified.finalArgs, { id: string }>>
+const possiblePatch = null as unknown as { args?: { id: Date } } | undefined
+const maybeMerged = applyCustomizationResult({}, { id: 'wire' }, possiblePatch)
+type _PossiblePatch = Expect<Equal<typeof maybeMerged.finalArgs.id, string | Date>>
+const optionalKey = null as unknown as { args: { id?: Date; extra?: number } }
+const optionalMerge = applyCustomizationResult({}, { id: 'wire' }, optionalKey)
+type _OptionalKey = Expect<Equal<typeof optionalMerge.finalArgs.id, string | Date | undefined>>
+type _OptionalNewKey = Expect<Equal<typeof optionalMerge.finalArgs.extra, number | undefined>>
+
+const customInput = (
+  ctx: { identity: string },
+  args: { at: Date },
+  extra: { enabled: boolean }
+) => ({
+  ctx: { identity: extra.enabled ? ctx.identity.length : 0 },
+  args: { at: args.at },
+  onSuccess: ({ ctx: original }: { ctx: { identity: string }; args: unknown; result: unknown }) => {
+    original.identity.toUpperCase()
+  }
+})
+const addedPromise = runCustomizationInput(
+  customInput,
+  { identity: 'user' },
+  {},
+  { at },
+  { enabled: true },
+  z.object({ at })
+)
+type _InputResult = Expect<Equal<Awaited<typeof addedPromise>, ReturnType<typeof customInput>>>
+const finalized = finalizeFunctionReturn('result', {
+  ctx: { identity: 'user' },
+  args: { at: new Date() },
+  added: customInput({ identity: 'user' }, { at: new Date() }, { enabled: true })
+})
+type _FinalizedWire = Expect<Equal<typeof finalized, Promise<unknown>>>

--- a/packages/zodvex/typechecks/init-pipeline.test-d.ts
+++ b/packages/zodvex/typechecks/init-pipeline.test-d.ts
@@ -1,0 +1,63 @@
+import { type GenericDataModel, type GenericQueryCtx, queryGeneric } from 'convex/server'
+import { z } from 'zod'
+import { zCustomMutation, zCustomQuery } from '../src/internal/functions/customFunctions'
+import { composeCustomizations, createZodvexBuilder } from '../src/internal/functions/init'
+import type { Equal, Expect } from './test-helpers'
+
+const codec = {
+  args: {},
+  input: (_ctx: GenericQueryCtx<GenericDataModel>, _args: Record<string, never>) => ({
+    ctx: { identity: 'user' },
+    args: {}
+  })
+}
+const composed = composeCustomizations(codec, {
+  args: { token: z.string() },
+  input: (ctx, args) => {
+    type _Ctx = Expect<Equal<typeof ctx.identity, string>>
+    type _Args = Expect<Equal<typeof args.token, string>>
+    // @ts-expect-error Composition must retain the actual codec context
+    ctx.missing
+    // @ts-expect-error Customization args are checked
+    const _unknownArg: string = args.missing
+    return { ctx: { identity: ctx.identity.length }, args: { token: new Date() } }
+  }
+})
+const composedResult = null as unknown as Awaited<ReturnType<typeof composed.input>>
+// Required user input must retain the produced argument type.
+if ('token' in composedResult.args) {
+  type _ResultArgs = Expect<Equal<typeof composedResult.args.token, Date>>
+}
+
+const builder = createZodvexBuilder(queryGeneric, codec, zCustomQuery)
+builder({
+  args: { n: z.number() },
+  handler: (ctx, args) => {
+    type _Ctx = Expect<Equal<typeof ctx.identity, string>>
+    type _Args = Expect<Equal<typeof args.n, number>>
+    // @ts-expect-error Factory must not return an unchecked callable
+    const _unknownArg: string = args.missing
+    return args.n
+  }
+})
+
+// @ts-expect-error A query factory must not register through a mutation adapter
+createZodvexBuilder(queryGeneric, codec, zCustomMutation)
+const customized = builder.withContext({
+  args: { token: z.string() },
+  input: (ctx, args) => {
+    type _Ctx = Expect<Equal<typeof ctx.identity, string>>
+    type _Args = Expect<Equal<typeof args.token, string>>
+    return { ctx: { authorized: true }, args: { when: new Date() } }
+  }
+})
+customized({
+  args: { n: z.number() },
+  handler: (ctx, args) => {
+    type _Authorized = Expect<Equal<typeof ctx.authorized, boolean>>
+    type _Date = Expect<Equal<typeof args.when, Date>>
+    // @ts-expect-error Produced customization args have precise runtime types
+    const _wire: string = args.when
+    return args.n
+  }
+})


### PR DESCRIPTION
Customization-produced arguments replace parsed handler values at runtime, but their types were intersected: replacing `count: number` with `count: string` inferred `never`. Handler inference now follows replacement semantics across all six builders, with full Zod and Mini.

The modern pipeline now retains schema, context, customization-result, and registration types through normalization, execution, composition, and initialization. Compiler tests exercise the actual implementation and reject wire values in decoded handlers, invalid returns, missing properties, primitive registrations, and swapped internal registration adapters. Optional patches retain their fallback types. Localized assertions remain at TypeScript's generic spread/conditional and Convex/Zod adapter boundaries; legacy public signatures remain available.

Runtime coverage verifies codec round-trips, replacement, original-context/base-argument success callbacks, and options/validators attached to shorthand functions.

Validation: full `validate:local` passed (2,360 library tests, 137 codemod tests, 58 example tests, typechecks, build, lint, consumer declarations, generated-output freshness). Independent review passed after compatibility fixes. Hotpot also passed full validation against the locally packaged candidate (1,861 tests, 5 existing skips, 4 CLI tests, build and demo typecheck); generated API unchanged and no application edits needed.
