### PR TITLE
docs: guide Zod 3 migration trials with compatibility checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ For zodvex's own types — `zx.id()`, `zx.date()`, `zx.codec()` — and exactly 
 
 ## Upgrading?
 
+Coming from convex-helpers and Zod 3? Use the [migration trial guide and agent
+skill](./docs/guide/migrating-from-zod3.md) to check behavior and memory evidence
+in your application.
+
 Read the [migration guide](./MIGRATION.md) for what changed in each release and why. Automated renames are available:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ docs site.
 | [`roadmap.md`](./roadmap.md) | Public roadmap — direction at the adopter's level. |
 | [`guide/`](./guide/) | User-facing feature guides (`zx`, codecs, date handling, rules & audit, streams, codegen, forms, …). |
 | [`migration/`](./migration/) | Version migration guides. |
+| [`skills/`](./skills/) | Portable agent instructions for supported migration workflows. |
 | `../README.md`, `../MIGRATION.md`, `../CHANGELOG.md` | Repo-root durable docs. |
 
 `decisions/` sits between the two: durable *rationale* (why we chose X), useful long-term but

--- a/docs/guide/custom-context.md
+++ b/docs/guide/custom-context.md
@@ -150,4 +150,8 @@ export const secureMutation = zm.withContext({
 })
 ```
 
-`onSuccess` runs after the handler and Zod return validation, seeing runtime types (e.g., `Date`, not timestamps).
+`onSuccess` runs after the handler and **before** Zod return validation/encoding.
+It receives the handler result, including decoded runtime values such as `Date`.
+The callback can therefore run even when return validation subsequently fails.
+This differs from convex-helpers' Zod 3 wrapper, which parses declared returns
+before calling the hook; check any dependent behavior when migrating.

--- a/docs/guide/migrating-from-zod3.md
+++ b/docs/guide/migrating-from-zod3.md
@@ -1,0 +1,29 @@
+# Trialing Zodvex from convex-helpers and Zod 3
+
+The [migration skill](../skills/migrate-convex-helpers-zod3/SKILL.md) helps an agent
+assess an existing application, migrate a representative slice, test behavior and
+prepare memory evidence. It is also suitable for teams that previously left
+Zodvex after a memory-related deployment failure.
+
+Download or copy the entire `docs/skills/migrate-convex-helpers-zod3` directory,
+including `references` and `agents`. Install it in your agent's skill directory,
+or ask your agent to read the `SKILL.md` and follow its linked references directly.
+For Codex, the user skill directory is `~/.codex/skills/`.
+
+A starting request:
+
+> Use $migrate-convex-helpers-zod3 to assess this app and trial a representative
+> migration in an isolated checkout. Preserve our stored data, auth and endpoint
+> behavior. Report compatibility findings and available memory evidence before
+> expanding the trial. Start with local checks.
+
+The skill supports endpoint adoption while keeping native Convex tables, followed
+by a separate modeled database trial. It does not assume that every app can
+immediately adopt `defineZodSchema`, or that a passing endpoint pilot measures
+the full Zodvex model graph.
+
+For memory diagnostics, use a release or maintainer-provided package containing
+`inspect-schema`; the released **v0.7.10 does not contain it**. Check the installed
+command rather than downloading an unspecified version. The inspector requires
+Node 22+ and a `defineZodSchema` export, and produces a local aggregate report.
+See [schema diagnostics](schema-diagnostics.md) for scope and interpretation.

--- a/docs/skills/migrate-convex-helpers-zod3/SKILL.md
+++ b/docs/skills/migrate-convex-helpers-zod3/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: migrate-convex-helpers-zod3
+description: Use when assessing or trialing a Convex application's migration from convex-helpers with Zod 3 to Zodvex, including teams returning after memory-related deployment failures.
+---
+
+# Try Zodvex in an existing Zod 3 application
+
+Produce a reversible migration trial and an evidence-based recommendation. Preserve
+the application's behavior, stored representation and authorization. A passing
+endpoint pilot is progress; it does not establish full application capacity.
+
+## Establish the comparison
+
+Read the application's instructions, package manifests and lockfile, Convex schema,
+function setup and relevant tests. Determine which imports really use Zod 3,
+including shared workspace packages and the installed helpers implementation.
+Record resolved Zod, Zodvex, helpers and Convex versions, runtime, baseline commit
+and existing test failures. Use the project's package manager and test commands.
+Verify the runtime inside the trial directory; directory-specific version
+managers can select a different Node version there.
+
+If the team previously left Zodvex, distinguish its current helpers/Zod 3 app from
+any archived Zodvex revision. Ask only for missing information that affects the
+trial: the previous failure stage, desired scope and any approved dev deployment.
+An old OOM report is not evidence that the current versions still fail.
+
+Work in a branch or isolated checkout consistent with the user's instructions.
+Keep the baseline reproducible. Pin the target packages or maintainer-supplied
+tarball; record its identity. Do not change unrelated dependencies to make the
+comparison easier. Run the relevant baseline checks before changing application
+code.
+
+## Migrate a representative slice
+
+Read [compatibility.md](references/compatibility.md) before changing imports or
+builders. Start with a real authenticated query/mutation pair and the schemas
+they actually use. Include a default, union, transformation or custom wrapper if
+the application relies on one. Avoid inventing features merely to make a demo.
+
+Endpoint adoption can retain native Convex tables and database access. Use the
+current public `zCustomQuery` / `zCustomMutation` builders with the application's
+existing customization. Keep old schemas explicitly on `zod/v3` and migrated
+schemas on `zod/v4`, after checking dependency compatibility. These schema
+instances cannot be mixed in one shape.
+
+Treat model/database adoption as its own step. Preserve table names, wire types,
+indexes and application checks; then verify decoded reads and encoded writes.
+Native tables cannot simply be mixed into `defineZodSchema`. Do not introduce
+manual internal table maps or cast native schemas into `initZodvex`.
+
+Run paired behavior checks on the selected operations, including rejected inputs,
+authorization, omitted versus null fields, defaults, returns and any success
+hooks. Resolve unintended changes instead of weakening assertions. Record an
+intentional behavior change for the user to assess. Continue unaffected work if
+one slice is blocked. Expand to the remaining application when that is within
+the requested scope.
+
+## Measure the candidate honestly
+
+Read [evidence.md](references/evidence.md) for diagnostic availability, privacy
+and deployment comparisons. Inspect the actual modeled schema when available;
+label a partial conversion as partial. Helpers-only/native schemas do not work
+with `inspect-schema`. Its local report cannot certify hosted memory capacity.
+
+For local-only requests, report deployment checks as unperformed; no deployment
+target question is needed. Otherwise use already approved dev deployments for
+the baseline/candidate comparison. If
+no target is authorized, finish local work and request the missing target before
+deploying. A trial does not require a production push, customer-data export or
+deleting existing rows. Keep bounded runtime checks representative of the app.
+
+## Deliver the trial
+
+Provide a reviewable diff and concise report containing:
+
+- **Scope:** endpoints/tables migrated, remaining Zod 3 usage and excluded paths.
+- **Identity:** baseline/candidate revisions and resolved dependency/build versions.
+- **Behavior:** checks run, results and each unresolved semantic difference.
+- **Performance evidence:** report scope, measured quantities, deployment/runtime
+  outcomes and checks not performed. Keep local memory separate from hosted results.
+- **Recommendation:** continue, ready for app review, or blocked by a named issue;
+  include how to return to the preserved baseline.
+
+Keep source, endpoint names, logs and diffs local by default. Prepare the aggregate
+diagnostic JSON and a separately reviewed summary for sharing; sending them is a
+separate action from preparing the migration.

--- a/docs/skills/migrate-convex-helpers-zod3/agents/openai.yaml
+++ b/docs/skills/migrate-convex-helpers-zod3/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Try Zodvex from Zod 3"
+  short_description: "Trial a Zod 3 migration with behavior and memory checks"
+  default_prompt: "Use $migrate-convex-helpers-zod3 to trial Zodvex in this application and report compatibility and memory evidence."

--- a/docs/skills/migrate-convex-helpers-zod3/references/compatibility.md
+++ b/docs/skills/migrate-convex-helpers-zod3/references/compatibility.md
@@ -1,0 +1,135 @@
+# Migration compatibility
+
+These notes describe Zodvex's September 2026 implementation. Verify the installed
+target: package version alone does not identify an unpublished build. The
+[boundary contract](https://github.com/panzacoder/zodvex/blob/1f415c47fa7659c860a3a813cb371020bde53c94/docs/decisions/2026-09-07-boundary-contract.md)
+records supported behavior and limitations.
+
+## Dependencies and coexistence
+
+Zodvex requires Zod 4. The current peer range begins at `^4.3.6`; the measured
+baseline is **4.5.4**. Installing an old Zod 3 package that happens to expose
+`zod/v4` does not satisfy that peer requirement or provide the measured memory
+improvements. Record the actual resolved version, not only the package range.
+
+Zod 4 packages include the `zod/v3` compatibility subpath. Before changing the
+root dependency, locate existing `from 'zod'` imports and determine which must
+continue using Zod 3. Preserve those via `zod/v3` where supported; use `zod/v4`
+for migrated code. Check third-party peers and workspace package resolution.
+Do not override incompatible peers or cast a Zod 3 schema into a Zod 4 shape.
+See [Zod's versioning guidance](https://zod.dev/v4/versioning).
+
+A partial migration can import both Zod runtimes into the same endpoint. Record
+that mixed state when interpreting memory; it need not represent the final
+Zodvex-only import graph.
+
+In tested helpers `0.1.113`, `convex-helpers/server/zod` re-exports Zod 3 custom
+builders backed by `zod/v3`. A mapper supporting multiple Zod versions does not
+make its function builders interchangeable. Inspect the customer's installed
+implementation, especially on older versions.
+
+## Endpoint-first adoption
+
+The public custom builders work without converting the database schema:
+
+```ts
+import { z } from 'zod/v4'
+import { zCustomQuery } from 'zodvex/server'
+import { NoOp } from 'convex-helpers/server/customFunctions'
+import { query } from './_generated/server'
+
+const zq = zCustomQuery(query, NoOp)
+
+export const greeting = zq({
+  args: { name: z.string() },
+  returns: z.string(),
+  handler: (_ctx, { name }) => `Hello ${name}`,
+})
+```
+
+`NoOp` is appropriate only for an operation that already needs no customization.
+For an authenticated operation, preserve its auth/ownership checks and existing
+customization. Native Convex validators in customization args can remain native;
+Zod-declared customization args also need migration. Preserve consumed/injected
+arguments, public/internal visibility and the order of DB wrappers.
+
+This path validates function boundaries and leaves `ctx.db` native. It does not
+test Zodvex's modeled database graph. Do not add an empty `defineZodSchema` and
+`wrapDb: false` merely to make `initZodvex` accept a native app. Neither
+`zodvex migrate` (old Zodvex API renames) nor `codemod` (Full/Mini conversion)
+performs this migration.
+
+## Behavior checks that matter
+
+Use representative application values before/after migration; use the current
+Zod 3 application as the behavioral reference, not a guessed equivalent schema.
+
+| Area | Check |
+| --- | --- |
+| Defaults | Zod 4 `.default()` returns an output default without parsing it; `.prefault()` can retain input-default processing. Defaults inside optional object properties can appear where Zod 3 omitted the key. Test absent, explicit undefined and explicit null separately at the applicable boundary. |
+| Records/unions | Enum-keyed records become exhaustive in Zod 4; `partialRecord` can express the former partial behavior. Single-argument `record` changes. Preserve discrimination, rejected variants and output shape. |
+| Transforms/refinements | Check input and output values, rejection and execution count. Return finalization encodes first and has a unidirectional-transform parsing fallback; do not assume ordinary transforms behave like reversible codecs. Current Zodvex boundaries use synchronous Zod operations. |
+| Return hooks | Tested helpers Zod 3 parses returns before `onSuccess`. Current Zodvex runs `onSuccess` before return validation/encoding, with the handler result. Test invalid results and transformed results; a hook may run for an eventual failure. If the app depends on the old order, resolve that explicitly before migrating the affected operation. |
+| Empty returns | Helpers normalizes undefined handler results to null before a declared return parse. Use an explicit `return null` for a migrated `returns: z.null()` function. |
+| Errors | Error payloads differ. Helpers' `ZodError` payload and Zodvex's contextual errors are not interchangeable. Preserve any client behavior that reads validation errors. |
+| Formats/object policies | Zod 4 tightens some formats and changes optionality/error APIs. Check used features against the official migration guide; retain strictness, unknown-key handling and missing-key behavior intentionally. |
+
+See [Zod's migration guide](https://zod.dev/v4/changelog). Preserve existing
+authorization tests and add negative cases for the boundaries being changed.
+Generated types or direct `_handler` calls alone do not exercise native Convex
+argument validators, serialization, authorization setup or database constraints.
+
+## Modeled database adoption
+
+Use `defineZodModel` and `defineZodSchema`, then initialize the six generated
+Convex builders through `initZodvex`. See the
+[builder guide](https://github.com/panzacoder/zodvex/blob/main/docs/guide/builders.md).
+`defineZodSchema` accepts Zodvex model/legacy entries, not arbitrary native
+`TableDefinition`s. It has no second schema-options parameter. Native auth or
+component tables and non-default schema options therefore need an explicit
+integration decision; do not force them through casts or silently drop them.
+
+Retain every table/index name, field wire type and schema policy. `zx.date()`
+stores numeric epoch milliseconds; an existing ISO-string field needs a matching
+codec if Date behavior is desired. A library migration does not authorize changing
+stored representations. Introduce codecs only for behavior the trial requires.
+
+`initZodvex` wraps modeled DB reads/writes; it does not supply application auth.
+Apply the existing customizations with `.withContext()` and use `defineContext`
+where a shared customization needs inference. `.withContext()` is not a chain
+of independent middlewares. With tested helpers `0.1.113`, passing its `customCtx`
+adapter directly to `.withContext()` can fail strict TypeScript because its
+`extra` parameter is required. Preserve the existing auth helper and use a
+contextually typed customization object (or `defineContext`), rather than a cast:
+
+```ts
+const authQuery = zq.withContext({
+  args: {},
+  input: async ctx => ({ ctx: await existingAuthHelper(ctx), args: {} }),
+})
+```
+
+Adapt this only to a helper that returns the existing added context; retain any
+argument processing or hooks from a richer customization. For existing triggers,
+`underlyingDb` composes the trigger layer below codecs, where it sees encoded
+wire values. Review security
+wrappers before changing their position.
+
+Modeled reads parse **full documents**, so existing rows may fail refinements,
+receive defaults or undergo transforms even without codecs. Insert/replace encode
+runtime values. Object patches encode supplied fields and preserve top-level
+undefined for deletion; they do not validate a merged complete document or its
+outer refinements. Union patches can require a complete variant. Check get,
+query/pagination, insert, replace and relevant patch/unset paths using actual
+application values.
+
+Code generation is optional for server validation and modeled DB codecs. Existing
+plain Convex clients still send/receive wire values. If the app needs Date/class
+values in frontend or outbound function calls, explicitly configure the
+appropriate registry/client integration and test that boundary; changing a
+server builder alone does not do this.
+
+Ordinary registry/client decoding warns and returns raw wire data by default when
+a schema parse fails. `onDecodeError: 'throw'` selects strict failure. Test the
+chosen policy before relying on runtime Date/class types after a failed decode;
+do not infer a strict client contract from the stricter modeled database path.

--- a/docs/skills/migrate-convex-helpers-zod3/references/evidence.md
+++ b/docs/skills/migrate-convex-helpers-zod3/references/evidence.md
@@ -1,0 +1,96 @@
+# Collecting useful evidence
+
+## Package and command availability
+
+`inspect-schema` landed after the **v0.7.10 release**. Main initially retained that
+package version, so a version string is insufficient. Use the project's locally
+installed Zodvex executable and check its help before invoking the command. Do
+not let an unpinned package-runner download silently select the candidate.
+
+If the command is absent, use a maintainer-supplied release or built tarball that
+contains it. Record the package version, full source commit and SHA-256 of the
+actual tarball; disclose any uncommitted build changes. The inspector's dependency
+version alone cannot distinguish two builds labeled `0.7.10`. Otherwise mark
+the diagnostic unavailable and continue compatibility checks. A source checkout
+must be built and packaged first; a local package-manager link can resolve a
+different Convex dependency tree and cause misleading nominal-type errors.
+
+## Local schema report
+
+Use **Node 22+**, the application's installed dependencies and its actual
+`defineZodSchema` default export. For example, with a local executable available:
+
+```sh
+./node_modules/.bin/zodvex inspect-schema convex/schema.ts > schema-report.json
+```
+
+Adapt the executable/input paths to the workspace layout. The command does not
+support Bun as its runtime. It cannot inspect a helpers-only/native Convex schema;
+do not create dummy models or undocumented table-map adapters to make a baseline
+look comparable. A partial modeled candidate reports only that candidate's scope.
+
+The command bundles and imports the trusted schema in fresh local Node processes.
+Schema module initializers can execute application code with the user's local
+environment and permissions. The diagnostic itself does not deploy or upload.
+Review import side effects before running it on an unfamiliar app.
+
+The output includes dependency/runtime versions, aggregate schema/codec/check
+counts, traversal coverage, bundle/module totals and three retained-memory import
+measurements. It excludes field/table names, literal values, source, file paths
+and schema hashes. Application stdout/stderr are discarded. Review the output
+before sharing; keep source, bundles, environment files and raw heap snapshots
+local.
+
+Interpretation:
+
+- Node retained heap is an import proxy, not hosted isolate memory, peak usage or
+  remaining headroom. A report does not predict whether the app fits.
+- Aggregate counts do not reconstruct dependencies, closure captures or module
+  topology. Incomplete traversal makes the definition census partial.
+- A schema import does not necessarily include the function registry, auth/client
+  imports or all state retained by a real endpoint.
+- Do not compare a native-only schema's bytes with a full modeled schema and call
+  it equal coverage. Do not sum heap and external bytes into a hosted budget.
+
+The [diagnostic guide](https://github.com/panzacoder/zodvex/blob/main/docs/guide/schema-diagnostics.md)
+defines the exact report contract. This JSON is a starting point for a maintainer
+to construct representative synthetic fixtures, not a schema reconstruction.
+
+## Deployment and runtime checks
+
+Distinguish dependency installation/type checking, deployment analysis, schema
+validation and function execution. Record the failed stage and a reviewed error
+summary. Avoid repeating deployments merely to seek a failure threshold.
+
+For an authorized dev deployment, compare preserved baseline and candidate using
+the same target and a bounded, relevant workload. Record CLI/dependency versions,
+local backend revision if applicable, candidate commit, commands and outcomes.
+Do not attribute a historic Cloud failure to today's backend or infer the backend
+revision from the CLI version. Report environment/data differences that prevent
+a matched comparison.
+
+A representative check should call real authenticated queries/mutations with
+synthetic or approved existing rows, confirm wire outputs, and verify any
+modeled codec operations. Native validation and serialization must be exercised
+before claiming deployment compatibility. Clean up only rows the trial creates.
+Do not turn off validation, unwrap DB codecs or reduce fixture coverage merely to
+obtain a passing memory result.
+
+The old table-count ceilings are not current limits. Convex changed deployment
+analysis and Zod 4.5 reduced allocations; neither proves that an arbitrary customer
+application now fits. A current successful deployment plus representative runtime
+checks establishes that tested app/workload, not a universal capacity promise.
+
+## Shareable handoff
+
+Prepare `schema-report.json` when available and a short, reviewed summary of:
+
+1. Baseline/candidate dependency versions and trial coverage.
+2. Whether installation, local behavior, deployment and runtime checks passed.
+3. Any semantic blocker, failed stage or skipped measurement.
+4. Which measured quantities changed under a matched comparison.
+
+Endpoint/table names, source revisions for private apps, raw error paths and logs
+can identify the application. Keep those in the private working report unless
+the customer chooses to share them. No account credentials or schema export is
+needed for the aggregate report.


### PR DESCRIPTION
Teams returning from convex-helpers/Zod 3 need a reversible way to test Zodvex against their existing behavior and memory concerns. Add a portable agent skill that guides an endpoint trial, separate modeled-DB adoption, and a reviewed diagnostic handoff.

The skill covers Zod 3/4 coexistence, defaults and transforms, auth/custom wrappers, and exact candidate package identity. It distinguishes local schema reports from hosted capacity and handles the unreleased `inspect-schema` command explicitly. Also correct the custom-context guide: `onSuccess` runs before return validation/encoding.

Validation: an independent agent used the skill on a representative Convex fixture, migrated three authenticated endpoints in two application files, and passed strict TypeScript plus 22 paired runtime checks. Schema, indexes, native endpoint and dependency lockfile were unchanged. Four additional wrapper probes confirmed the documented hook-order difference. Skill frontmatter and local links pass validation; a packed installation successfully ran the diagnostic on a synthetic schema.

These are local compatibility checks, not a customer migration, actual deployment or memory-capacity result. No library runtime changes or release are included.
